### PR TITLE
Properly filter params

### DIFF
--- a/lib/lograge/log_subscriber.rb
+++ b/lib/lograge/log_subscriber.rb
@@ -5,7 +5,8 @@ module Lograge
   class RequestLogSubscriber < ActiveSupport::LogSubscriber
     def process_action(event)
       payload = event.payload
-      message = "#{payload[:method]} #{payload[:path]} format=#{payload[:format]} action=#{payload[:params]['controller']}##{payload[:params]['action']}"
+      filtered_path = payload[:path].split("?").first # ensures no qstring sticks around
+      message = "#{payload[:method]} #{filtered_path} format=#{payload[:format]} action=#{payload[:params]['controller']}##{payload[:params]['action']}"
       message << extract_status(payload)
       message << runtimes(event)
       message << location(event)


### PR DESCRIPTION
this enforces removal of the query string before it hits the logger.
