### PR TITLE
Handle Rails 3.0.x request format payload

### DIFF
--- a/lib/lograge/log_subscriber.rb
+++ b/lib/lograge/log_subscriber.rb
@@ -5,7 +5,7 @@ module Lograge
   class RequestLogSubscriber < ActiveSupport::LogSubscriber
     def process_action(event)
       payload = event.payload
-      message = "#{payload[:method]} #{payload[:path]} format=#{payload[:format]} action=#{payload[:params]['controller']}##{payload[:params]['action']}"
+      message = "#{payload[:method]} #{payload[:path]} format=#{extract_format(payload)} action=#{payload[:params]['controller']}##{payload[:params]['action']}"
       message << extract_status(payload)
       message << runtimes(event)
       message << location(event)
@@ -18,6 +18,14 @@ module Lograge
     end
 
     private
+
+    def extract_format(payload)
+      if ::ActionPack::VERSION::MINOR == 0
+        payload[:formats].first
+      else
+        payload[:format]
+      end
+    end
 
     def extract_status(payload)
       if payload[:status]


### PR DESCRIPTION
Hi,

In Rails 3.0.x, somewhat annoyingly the instrumentation payload is different, including a list of formats rather than a single request format:

``` ruby
{
  :controller=>"HomepageController",
  :action=>"index",
  :params=>{"controller"=>"homepage", "action"=>"index"},
  :formats=>[:html],
  :method=>"GET",
  :path=>"/",
  :status=>302,
  :view_runtime=>nil,
  :db_runtime=>nil
}
```

The included patch is the rather bodgy way of supporting Rails 3.0.x we're using in our fork - if you'd prefer this to be done a different way, just let me know and I'm happy to amend it accordingly.

Cheers,
Simon

p.s. thanks for creating this gem; I can't stop tailing our logs now, it's bliss. :-)
