### PR TITLE
Format only float values with decimals.

### DIFF
--- a/lib/lograge/log_subscriber.rb
+++ b/lib/lograge/log_subscriber.rb
@@ -30,7 +30,7 @@ module Lograge
         # a single quote
         data[key] = "'#{data[key]}'" if key == :error
         # Ensure that we always have exactly two decimals
-        data[key] = "%.2f" % data[key] if data[key].is_a? Numeric
+        data[key] = "%.2f" % data[key] if data[key].is_a? Float
 
         message << "#{key}=#{data[key]}"
         message

--- a/spec/lograge_logsubscriber_spec.rb
+++ b/spec/lograge_logsubscriber_spec.rb
@@ -47,12 +47,12 @@ describe Lograge::RequestLogSubscriber do
 
     it "should start the log line with the HTTP method" do
       subscriber.process_action(event)
-      log_output.string.starts_with?('method=GET').should == true
+      log_output.string.starts_with?('method=GET ').should == true
     end
 
     it "should include the status code" do
       subscriber.process_action(event)
-      log_output.string.should include('status=200')
+      log_output.string.should include('status=200 ')
     end
 
     it "should include the controller and action" do
@@ -62,12 +62,12 @@ describe Lograge::RequestLogSubscriber do
 
     it "should include the duration" do
       subscriber.process_action(event)
-      log_output.string.should =~ /duration=[\.0-9]{4,4}/
+      log_output.string.should =~ /duration=[\.0-9]{4,4} /
     end
 
     it "should include the view rendering time" do
       subscriber.process_action(event)
-      log_output.string.should =~ /view=0.01/
+      log_output.string.should =~ /view=0.01 /
     end
 
     it "should include the database rendering time" do
@@ -79,15 +79,15 @@ describe Lograge::RequestLogSubscriber do
       event.payload[:status] = nil
       event.payload[:exception] = ['AbstractController::ActionNotFound', 'Route not found']
       subscriber.process_action(event)
-      log_output.string.should =~ /status=500/
-      log_output.string.should =~ /error='AbstractController::ActionNotFound:Route not found'/
+      log_output.string.should =~ /status=500 /
+      log_output.string.should =~ /error='AbstractController::ActionNotFound:Route not found' /
     end
 
     it "should return an unknown status when no status or exception is found" do
       event.payload[:status] = nil
       event.payload[:exception] = nil
       subscriber.process_action(event)
-      log_output.string.should =~ /status=0/
+      log_output.string.should =~ /status=0 /
     end
 
     describe "with a redirect" do


### PR DESCRIPTION
Meh, looks like I screwed up a bit, I'm sorry.

With the #19 Pull Request, the HTTP status code started to get formatted as a float, as I formatted _any_ Numeric value with 2 decimals. Turns out, the status is not a float...

This pull request fixes the bug and slightly adapts the specs by adding the trailing whitespace to make sure to match the actual values and not just the beginning of them to catch this issue.

Again, I'm really sorry for that.
