### PR TITLE
Allow to define the log level

### DIFF
--- a/lib/lograge.rb
+++ b/lib/lograge.rb
@@ -24,6 +24,10 @@ module Lograge
     end
   end
 
+  # Loglines are emitted with this log level
+  mattr_accessor :log_level
+  self.log_level = :info
+
   # The emitted log format
   #
   # Currently supported formats are>
@@ -60,6 +64,7 @@ module Lograge
     Lograge.remove_existing_log_subscriptions
     Lograge::RequestLogSubscriber.attach_to :action_controller
     Lograge.custom_options = app.config.lograge.custom_options
+    Lograge.log_level = app.config.lograge.log_level || :info
     Lograge.log_format = app.config.lograge.log_format || :lograge
     case Lograge.log_format.to_s
     when "logstash"

--- a/lib/lograge/log_subscriber.rb
+++ b/lib/lograge/log_subscriber.rb
@@ -12,7 +12,8 @@ module Lograge
       data.merge! location(event)
       data.merge! custom_options(event)
 
-      logger.info send(:"process_action_#{Lograge.log_format}", data)
+      line = send(:"process_action_#{Lograge.log_format}", data)
+      logger.send(Lograge.log_level, line)
     end
 
     LOGRAGE_FIELDS = [


### PR DESCRIPTION
Sometimes, especially with legacy apps, people log stuff on info that can't easily be turned of.

A simple solution is to just kick the log level a bit (e.g. to error) to make sure those stray infos get cut off. With lograge being able to emit its logs as error (or whatever loglevel necessary) it is easily possible to dry up the logfiles.

Another possible alternative would be to be able to define a custom logger for lograge and generate those logs into a new file (or wherever desired) and just keep the default logs as is (or well, redirect them to `/dev/null`). This would remove the need for core patches to silence default loggers at all, as we would just not care about the default logs anymore.

What do you think?
