### PR TITLE
Added support for sending messages to Graylog2

### DIFF
--- a/lib/lograge/log_subscriber.rb
+++ b/lib/lograge/log_subscriber.rb
@@ -43,6 +43,20 @@ module Lograge
       event.to_json
     end
 
+    def process_action_graylog2(data)
+      # Cloning because we don't want to mess with the original when mutating keys.
+      my = data.clone
+
+      base = {
+        :short_message => "[#{my[:status]}] #{my[:method]} #{my[:path]} (#{my[:controller]}##{my[:action]})"
+      }
+
+      # Add underscore to every key to follow GELF additional field syntax.
+      my.keys.each { |k| my["_#{k}".to_sym] = my[k]; my.delete(k) }
+
+      my.merge(base)
+    end
+
     def redirect_to(event)
       Thread.current[:lograge_location] = event.payload[:location]
     end

--- a/lib/lograge/version.rb
+++ b/lib/lograge/version.rb
@@ -1,3 +1,3 @@
 module Lograge
-  VERSION = "0.1.2"
+  VERSION = "0.2.0"
 end

--- a/spec/lograge_logsubscriber_spec.rb
+++ b/spec/lograge_logsubscriber_spec.rb
@@ -196,6 +196,107 @@ describe Lograge::RequestLogSubscriber do
     end
   end
 
+  describe "when processing an action with graylog2 output" do
+    before do
+      Lograge::log_format = :graylog2
+    end
+
+    it "should include the URL in the log output" do
+      subscriber.process_action(event)
+      log_output.string.should include(':_path=>"/home"')
+    end
+
+    it "should start include the HTTP method" do
+      subscriber.process_action(event)
+      log_output.string.should include(':_method=>"GET"')
+    end
+
+    it "should include the status code" do
+      subscriber.process_action(event)
+      log_output.string.should include(':_status=>200')    end
+
+    it "should include the controller and action" do
+      subscriber.process_action(event)
+      log_output.string.should include(':_controller=>"home"')
+      log_output.string.should include(':_action=>"index"')
+    end
+
+    it "should include the duration" do
+      subscriber.process_action(event)
+      log_output.string.should =~ /:_duration=>\d+\.\d{0,2}/
+    end
+
+    it "should include the view rendering time" do
+      subscriber.process_action(event)
+      log_output.string.should include(':_view=>0.01')
+    end
+
+    it "should include the database rendering time" do
+      subscriber.process_action(event)
+      log_output.string.should include(':_db=>0.02')
+    end
+
+    it "should add a 500 status when an exception occurred" do
+      event.payload[:status] = nil
+      event.payload[:exception] = ['AbstractController::ActionNotFound', 'Route not found']
+      subscriber.process_action(event)
+      log_output.string.should include(':_status=>500')
+      log_output.string.should include(':_error=>"AbstractController::ActionNotFound:Route not found"')
+    end
+
+    it "should return an unknown status when no status or exception is found" do
+      event.payload[:status] = nil
+      event.payload[:exception] = nil
+      subscriber.process_action(event)
+      log_output.string.should include(':_status=>0')
+    end
+
+    describe "with a redirect" do
+      before do
+        Thread.current[:lograge_location] = "http://www.example.com"
+      end
+
+      it "should add the location to the log line" do
+        subscriber.process_action(event)
+        log_output.string.should include(':_location=>"http://www.example.com"')
+      end
+
+      it "should remove the thread local variable" do
+        subscriber.process_action(event)
+        Thread.current[:lograge_location].should == nil
+      end
+    end
+
+    it "should not include a location by default" do
+      subscriber.process_action(event)
+      log_output.string.should_not =~ /"location":/
+    end
+  end
+
+  describe "with custom_options configured for graylog2 output" do
+    before do
+      Lograge::log_format = :graylog2
+    end
+
+    it "should combine the hash properly for the output" do
+      Lograge.custom_options = {:data => "value"}
+      subscriber.process_action(event)
+      log_output.string.should include(':_data=>"value"')
+    end
+
+    it "should combine the output of a lambda properly" do
+      Lograge.custom_options = lambda {|event| {:data => "value"}}
+      subscriber.process_action(event)
+      log_output.string.should include(':_data=>"value"')
+    end
+
+    it "should work if the method returns nil" do
+      Lograge.custom_options = lambda {|event| nil}
+      subscriber.process_action(event)
+      log_output.string.should be_present
+    end
+  end
+
   describe "with custom_options configured for lograge output" do
     before do
       Lograge::log_format = :lograge


### PR DESCRIPTION
Uses the GELF format and requires at least version 1.4.0 of the GELF gem as logger for proper formatting. (https://rubygems.org/gems/gelf)

No dependencies added to lograge. It just returns a Hash, picked up by the GELF gem logger.

The `log_output` in the tests is always a String, no matter what `process_action` actually returned. `process_action_graylog2` is returning a Hash, not a String. I did not want to change so much in the tests and just test against the String representation of the Hash now.  (Which is fine IMO)

![Screen Shot 2013-01-26 at 19 43 56](https://f.cloud.github.com/assets/35022/100082/601b0078-67e8-11e2-9991-ec225b962823.png)
