### PR TITLE
Add filtering for custom options, same as the standard rails logger. Fixes #28

### DIFF
--- a/lib/lograge/log_subscriber.rb
+++ b/lib/lograge/log_subscriber.rb
@@ -97,7 +97,7 @@ module Lograge
     end
 
     def custom_options(event)
-      Lograge.custom_options(event) || {}
+      filter_params(Lograge.custom_options(event) || {})
     end
 
     def runtimes(event)
@@ -118,6 +118,10 @@ module Lograge
       else
         {}
       end
+    end
+
+    def filter_params(params)
+      Lograge.param_filter.filter(params)
     end
   end
 end

--- a/spec/lograge_logsubscriber_spec.rb
+++ b/spec/lograge_logsubscriber_spec.rb
@@ -95,6 +95,17 @@ describe Lograge::RequestLogSubscriber do
       log_output.string.should =~ /status=0 /
     end
 
+    describe "with custom options" do
+      before do
+        Lograge::custom_options = {:params => {:password => "asdfasdf"}}
+      end
+
+      it "should filter out specified parameters when custom parameters are passed" do
+        subscriber.process_action(event)
+        log_output.string.should =~ /[FILTERED]/
+      end
+    end
+
     describe "with a redirect" do
       before do
         Thread.current[:lograge_location] = "http://www.example.com"


### PR DESCRIPTION
This applies filtering for parameters defined in `config.filter_parameters`.

For example, I'm using `append_info_to_payload` to append `request.params` to the payload provided to lograge - but as a result, passwords in those params are showing in the logs. This applies the same filtering as the standard Rails logger.
