### PR TITLE
Add params to all requests

### DIFF
--- a/spec/lograge_logsubscriber_spec.rb
+++ b/spec/lograge_logsubscriber_spec.rb
@@ -22,8 +22,8 @@ describe Lograge::RequestLogSubscriber do
   let(:event) {
     ActiveSupport::Notifications::Event.new(
       'process_action.action_controller', Time.now, Time.now, 2, {
-        status: 200, format: 'application/json', method: 'GET', path: '/home?foo=bar', params: {
-          'controller' => 'home', 'action' => 'index', 'foo' => 'bar'
+        status: 200, format: 'application/json', method: 'GET', path: '/home?foo=bar&baz=yay', params: {
+          'controller' => 'home', 'action' => 'index', 'foo' => 'bar', 'baz' => 'yay'
         }, db_runtime: 0.02, view_runtime: 0.01
       }
     )
@@ -45,9 +45,9 @@ describe Lograge::RequestLogSubscriber do
       log_output.string.should include('/home')
     end
 
-    it "should not include the query string in the url" do
+    it "should include the query string in the url" do
       subscriber.process_action(event)
-      log_output.string.should_not include('?foo=bar')
+      log_output.string.should include('params=foo:bar,baz:yay')
     end
 
     it "should start the log line with the HTTP method" do


### PR DESCRIPTION
What we end up with is something like:

```
method=GET path=/jobs/833552.json params=id:123,name:hello format=json controller=jobs action=show status=200 duration=58.33 view=40.43 db=15.26
```
