### PR TITLE
Setup @message for logstash/kibana

### DIFF
--- a/lib/lograge/log_subscriber.rb
+++ b/lib/lograge/log_subscriber.rb
@@ -41,7 +41,7 @@ module Lograge
 
     def process_action_logstash(data)
       event = LogStash::Event.new("@fields" => data)
-      event.message = "#{data[:method]} #{data[:path]} #{data[:status} #{data[:duration]}s #{data[:controller]}##{data[:action]}"
+      event.message = "[#{data[:status]}] #{data[:method]} #{data[:path]} (#{data[:controller]}##{data[:action]})"
       event.to_json
     end
 


### PR DESCRIPTION
This mimics the format in code for short message of graylog2, and should provide a more human-friendly @message when logstash is viewed through a default kibana setup.
