### PR TITLE
Ensure Rails3 testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ source "http://rubygems.org"
 gemspec
 
 group :test do
-  gem 'actionpack'
+  gem 'actionpack', '~> 3'
   gem 'logstash-event'
 end

--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
   # specify any dependencies here; for example:
   s.add_development_dependency "rspec"
   s.add_development_dependency "guard-rspec"
-  s.add_runtime_dependency "activesupport"
-  s.add_runtime_dependency "actionpack"
+  s.add_runtime_dependency "activesupport", '~> 3'
+  s.add_runtime_dependency "actionpack", '~> 3'
 end


### PR DESCRIPTION
With the release of Rails 4, `bundle` will install incompatible versions of `actionpack` and `activesupport` unless we enforce Rails 3 versions.  Versions ~> 4 will break testing.
