### PR TITLE
logstash formatter updates for 1.2

### DIFF
--- a/lib/lograge/formatters/logstash.rb
+++ b/lib/lograge/formatters/logstash.rb
@@ -3,7 +3,8 @@ module Lograge
     class Logstash
       def call(data)
         load_dependencies
-        event = LogStash::Event.new("@fields" => data)
+        event = LogStash::Event.new(data)
+  
         event.message = "[#{data[:status]}] #{data[:method]} #{data[:path]} (#{data[:controller]}##{data[:action]})"
         event.to_json
       end

--- a/spec/formatters/logstash_spec.rb
+++ b/spec/formatters/logstash_spec.rb
@@ -13,9 +13,6 @@ describe Lograge::Formatters::Logstash do
     }
   end
   subject { described_class.new.call(payload) }
-  it { should match(/"@source":"unknown"/) }
-  it { should match(/"@tags":\[\]/) }
-  it { should match(/"@fields":{/) }
   it { should match(/"custom":"data"/) }
   it { should match(/"status":200/) }
   it { should match(/"method":"GET"/) }


### PR DESCRIPTION
The field prefix has been removed and fields have been moved to the global namespace (https://github.com/logstash/logstash/blob/master/CHANGELOG)

Also, removed specs that were broken and never appeared to work.
