### PR TITLE
Added config to keep original rails log and set to use custom logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,20 @@ MyApp::Application.configure do
 end
 ```
 
+You can also keep the original (and verbose) Rails logger by following this configuration:
+
+```ruby
+MyApp::Application.configure do
+  config.lograge.keep_original_rails_log = true
+
+  # Rails 4+
+  config.lograge.logger = ActiveSupport::Logger.new "#{Rails.root}/log/lograge_#{Rails.env}.log"
+
+  # Rails 3.2
+  # config.lograge.logger = ActiveSupport::BufferedLoggerLogger.new "#{Rails.root}/log/lograge_#{Rails.env}.log"
+end
+```
+
 You can then add custom variables to the event to be used in `custom_options` (available via the `event.payload` hash)
 
 ```ruby

--- a/lib/lograge.rb
+++ b/lib/lograge.rb
@@ -117,8 +117,14 @@ module Lograge
   def self.setup(app)
     self.application = app
     app.config.action_dispatch.rack_cache[:verbose] = false if app.config.action_dispatch.rack_cache
-    require 'lograge/rails_ext/rack/logger'
-    Lograge.remove_existing_log_subscriptions
+
+    unless app.config.lograge.keep_original_rails_log
+      require 'lograge/rails_ext/rack/logger'
+      Lograge.remove_existing_log_subscriptions
+    end
+
+    Lograge.logger = app.config.lograge.logger
+
     Lograge::RequestLogSubscriber.attach_to :action_controller
     Lograge.custom_options = lograge_config.custom_options
     Lograge.before_format = lograge_config.before_format

--- a/spec/lograge_spec.rb
+++ b/spec/lograge_spec.rb
@@ -39,6 +39,25 @@ describe Lograge do
     end
   end
 
+  describe 'keep_original_rails_log option' do
+    context 'when keep_original_rails_log is true' do
+      let(:app_config) do
+        double(config:
+          ActiveSupport::OrderedOptions.new.tap do |config|
+            config.action_dispatch = double(rack_cache: false)
+            config.lograge = ActiveSupport::OrderedOptions.new
+            config.lograge.keep_original_rails_log = true
+          end
+        )
+      end
+
+      it "does not remove Rails' subscribers" do
+        expect(Lograge).to_not receive(:remove_existing_log_subscriptions)
+        Lograge.setup(app_config)
+      end
+    end
+  end
+
   describe 'deprecated log_format interpreter' do
     let(:app_config) do
       double(config:


### PR DESCRIPTION
This patch introduce an additional flag `keep_original_rails_log` to prevent lograge from unsubscribing the original Rails loggers. Also it sets the `Lograge.logger` to a custom one as configured.

By adding the following lines to **application.rb**, we can configure lograge to write to another file and leave the original Rails' log untouched. 
````
config.lograge.keep_original_rails_log = true
config.lograge.logger = ActiveSupport::BufferedLogger.new "#{Rails.root}/log/lograge_#{Rails.env}.log"
````
