### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ MyApp::Application.configure do
 end
 ```
 
-You can then add custom variables to the event to be used in custom_options
+You can then add custom variables to the event to be used in custom_options (available in the event.payload[] array)
 
 ```ruby
 # app/controllers/application_controller.rb


### PR DESCRIPTION
It took me a while to make the connection between 

``` ruby
payload[:host] = request.host
```

in the controller and

``` ruby
event.payload[:host]
```

in the custom_options lambda. This or something like it should make it a little more clear.
