### PR TITLE
Follow hash syntax for event["message"] for logstash-event v1.4.x

### DIFF
--- a/lib/lograge/formatters/logstash.rb
+++ b/lib/lograge/formatters/logstash.rb
@@ -5,7 +5,7 @@ module Lograge
         load_dependencies
         event = LogStash::Event.new(data)
   
-        event.message = "[#{data[:status]}] #{data[:method]} #{data[:path]} (#{data[:controller]}##{data[:action]})"
+        event["message"] = "[#{data[:status]}] #{data[:method]} #{data[:path]} (#{data[:controller]}##{data[:action]})"
         event.to_json
       end
 


### PR DESCRIPTION
This is for people who are using the logstash gem version 1.3+.

They remove the event.message accessor and make you use the ["message"] format instead.