### PR TITLE
Timestamp

### DIFF
--- a/lib/lograge/formatters/key_value.rb
+++ b/lib/lograge/formatters/key_value.rb
@@ -1,11 +1,6 @@
 module Lograge
   module Formatters
     class KeyValue
-      LOGRAGE_FIELDS = [
-        :time, :method, :path, :format, :controller, :action, :status, :error,
-        :duration, :view, :db, :location
-      ]
-
       def call(data)
         fields = fields_to_display(data)
 

--- a/lib/lograge/version.rb
+++ b/lib/lograge/version.rb
@@ -1,3 +1,3 @@
 module Lograge
-  VERSION = '0.4.0'
+  VERSION = '0.3.0'
 end

--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -2,7 +2,7 @@
 require './lib/lograge/version'
 
 Gem::Specification.new do |s|
-  s.name        = 'lograge-with-time'
+  s.name        = 'lograge'
   s.version     = Lograge::VERSION
   s.authors     = ['Mathias Meyer']
   s.email       = ['meyer@paperplanes.de']


### PR DESCRIPTION
Prepended time in logs. Time of the request is an important part of the log, it should be there as a first field.
