### PR TITLE
Redundant/confusing info in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,15 +225,6 @@ However, the payload does already contain the params hash, so you can easily
 add it in manually using `custom_options`:
 
 ```ruby
-config.lograge.custom_options = lambda do |event|
-  {params: event.payload[:params].except('controller', 'action', 'format')} #exclude redundant params
-end
-```
-
-In the meantime, if you want to log parameters in your application, you can use
-the following snippet:
-
-```ruby
 # production.rb
 YourApp::Application.configure do
   config.lograge.enabled = true


### PR DESCRIPTION
Hi,
maybe I'm understanding something wrong, but aren't these snippets functionally equal (except for the `format` being excluded and string vs. symbol key):

``` ruby
config.lograge.custom_options = lambda do |event|
  {params: event.payload[:params].except('controller', 'action', 'format')} #exclude redundant params
end
```

and 

``` ruby
config.lograge.custom_options = lambda do |event|
  params = event.payload[:params].reject do |k|
    ['controller', 'action'].include? k
  end

  { "params" => params }
end
```

They are both listed in the 'What is doesn't do'-section directly after one another - if they indeed do both the same thing, then removing the second example (as it seems a bit convoluted) would reduce confusion.

All the best,
Fabian
