### PR TITLE
Make sure rack_cache[:verbose] can be set

### DIFF
--- a/lib/lograge.rb
+++ b/lib/lograge.rb
@@ -116,7 +116,7 @@ module Lograge
 
   def self.setup(app)
     self.application = app
-    app.config.action_dispatch.rack_cache[:verbose] = false if app.config.action_dispatch.rack_cache
+    app.config.action_dispatch.rack_cache[:verbose] = false if rack_cache_hashlike?(app)
 
     unless app.config.lograge.keep_original_rails_log
       require 'lograge/rails_ext/rack/logger'
@@ -134,6 +134,11 @@ module Lograge
     Lograge.ignore_actions(lograge_config.ignore_actions)
     Lograge.ignore(lograge_config.ignore_custom)
   end
+
+  def rack_cache_hashlike?(app)
+    app.config.action_dispatch.rack_cache && app.config.action_dispatch.rack_cache.respond_to?(:[]=)
+  end
+  private_class_method :rack_cache_hashlike?
 
   # TODO: Remove with version 1.0
 

--- a/spec/lograge_spec.rb
+++ b/spec/lograge_spec.rb
@@ -58,6 +58,44 @@ describe Lograge do
     end
   end
 
+  describe 'disabling rack_cache verbosity' do
+    subject { -> { Lograge.setup(app_config) } }
+    let(:app_config) do
+      double(config:
+        ActiveSupport::OrderedOptions.new.tap do |config|
+          config.action_dispatch = config_option
+          config.lograge = ActiveSupport::OrderedOptions.new
+          config.lograge.keep_original_rails_log = true
+        end
+      )
+    end
+    let(:config_option) { double(rack_cache: rack_cache) }
+
+    context 'when rack_cache is false' do
+      let(:rack_cache) { false }
+
+      it 'does not change config option' do
+        expect(subject).to_not change { config_option.rack_cache }
+      end
+    end
+
+    context 'when rack_cache is a hash' do
+      let(:rack_cache) { { foo: 'bar', verbose: true } }
+
+      it 'sets verbose to false' do
+        expect(subject).to change { config_option.rack_cache[:verbose] }.to(false)
+      end
+    end
+
+    context 'when rack_cache is true' do
+      let(:rack_cache) { true }
+
+      it 'does not change config option' do
+        expect(subject).to_not change { config_option.rack_cache }
+      end
+    end
+  end
+
   describe 'deprecated log_format interpreter' do
     let(:app_config) do
       double(config:


### PR DESCRIPTION
Before this change, the following config setting which is provided as
example in production.rb of current rails versions:

config.action_dispatch.rack_cache = true

would result in a startup failure.

Fixes https://github.com/roidrage/lograge/issues/52