### PR TITLE
Add Rubinius 2 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.2.0
   - jruby
   - jruby-head
+  - rbx-2
 env:
   global:
     - JRUBY_OPTS='-J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Djruby.compile.mode=OFF -J-Djruby.compile.invokedynamic=false'


### PR DESCRIPTION
In my local tests the latest version of Rubinius worked. 
I think it makes sense to support it then.