### PR TITLE
Follow hash syntax for logstash-event v1.4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 * Make sure rack_cache[:verbose] can be set #103
+* Follow hash syntax for logstash-event v1.4.x #75
 
 ### Other
 * Use https in Gemfile #104

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ gemspec
 
 group :test do
   gem 'actionpack'
+  # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
+  # Using the tag is an attempt of having a stable version to test against where we can ensure that
+  # we test against the correct code.
   gem 'logstash-event', git: 'https://github.com/elasticsearch/logstash.git', tag: '1.5'
   gem 'rubocop'
   gem 'lines'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 
 group :test do
   gem 'actionpack'
-  gem 'logstash-event', git: 'git@github.com:elasticsearch/logstash.git', tag: '>1.5'
+  gem 'logstash-event', git: 'https://github.com/elasticsearch/logstash.git', tag: '1.5'
   gem 'rubocop'
   gem 'lines'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 
 group :test do
   gem 'actionpack'
-  gem 'logstash-event', '1.1.5'
+  gem 'logstash-event', git: 'git@github.com:elasticsearch/logstash.git', tag: '>1.5'
   gem 'rubocop'
   gem 'lines'
 end

--- a/gemfiles/Gemfile.actionpack3.2
+++ b/gemfiles/Gemfile.actionpack3.2
@@ -1,10 +1,13 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in lograge.gemspec
 gemspec :path => ".."
 
 group :test do
   gem 'actionpack', '~> 3.2.0'
+  # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
+  # Using the tag is an attempt of having a stable version to test against where we can ensure that
+  # we test against the correct code.
   gem 'logstash-event', git: 'https://github.com/elasticsearch/logstash.git', tag: '1.5'
   gem 'lines'
   gem 'rubocop'

--- a/gemfiles/Gemfile.actionpack3.2
+++ b/gemfiles/Gemfile.actionpack3.2
@@ -5,7 +5,7 @@ gemspec :path => ".."
 
 group :test do
   gem 'actionpack', '~> 3.2.0'
-  gem 'logstash-event', '1.1.5'
+  gem 'logstash-event', git: 'https://github.com/elasticsearch/logstash.git', tag: '1.5'
   gem 'lines'
   gem 'rubocop'
 end

--- a/gemfiles/Gemfile.actionpack4.0
+++ b/gemfiles/Gemfile.actionpack4.0
@@ -5,7 +5,7 @@ gemspec :path => ".."
 
 group :test do
   gem 'actionpack', '~> 4.0.0'
-  gem 'logstash-event', '1.1.5'
+  gem 'logstash-event', git: 'https://github.com/elasticsearch/logstash.git', tag: '1.5'
   gem 'lines'
   gem 'rubocop'
 end

--- a/gemfiles/Gemfile.actionpack4.0
+++ b/gemfiles/Gemfile.actionpack4.0
@@ -1,10 +1,13 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in lograge.gemspec
 gemspec :path => ".."
 
 group :test do
   gem 'actionpack', '~> 4.0.0'
+  # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
+  # Using the tag is an attempt of having a stable version to test against where we can ensure that
+  # we test against the correct code.
   gem 'logstash-event', git: 'https://github.com/elasticsearch/logstash.git', tag: '1.5'
   gem 'lines'
   gem 'rubocop'

--- a/gemfiles/Gemfile.actionpack4.2
+++ b/gemfiles/Gemfile.actionpack4.2
@@ -1,10 +1,13 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in lograge.gemspec
 gemspec :path => ".."
 
 group :test do
   gem 'actionpack', '~> 4.2.0'
+  # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
+  # Using the tag is an attempt of having a stable version to test against where we can ensure that
+  # we test against the correct code.
   gem 'logstash-event', git: 'https://github.com/elasticsearch/logstash.git', tag: '1.5'
   gem 'lines'
   gem 'rubocop'

--- a/gemfiles/Gemfile.actionpack4.2
+++ b/gemfiles/Gemfile.actionpack4.2
@@ -5,7 +5,7 @@ gemspec :path => ".."
 
 group :test do
   gem 'actionpack', '~> 4.2.0'
-  gem 'logstash-event', '1.1.5'
+  gem 'logstash-event', git: 'https://github.com/elasticsearch/logstash.git', tag: '1.5'
   gem 'lines'
   gem 'rubocop'
 end

--- a/lib/lograge/formatters/logstash.rb
+++ b/lib/lograge/formatters/logstash.rb
@@ -5,7 +5,7 @@ module Lograge
         load_dependencies
         event = LogStash::Event.new(data)
 
-        event.message = "[#{data[:status]}] #{data[:method]} #{data[:path]} (#{data[:controller]}##{data[:action]})"
+        event['message'] = "[#{data[:status]}] #{data[:method]} #{data[:path]} (#{data[:controller]}##{data[:action]})"
         event.to_json
       end
 

--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 require './lib/lograge/version'
 
 Gem::Specification.new do |s|
@@ -13,7 +12,6 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files lib`.split("\n")
 
-  # specify any dependencies here; for example:
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'guard-rspec'
   s.add_runtime_dependency 'activesupport', '>= 3'


### PR DESCRIPTION
This is a working version of #75 and includes the exact same change.
It will break backwards compability with < 1.4.x for logstash users.

TODO: 
- [x] Update changelog
- [x] Update dependency in Gemfile