### PR TITLE
Log RecordNotFound as 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 * Make sure rack_cache[:verbose] can be set #103
 * Follow hash syntax for logstash-event v1.4.x #75
+* Log RecordNotFound as 404 #27, #110, #112
 
 ### Other
 * Use https in Gemfile #104

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 
 group :test do
   gem 'actionpack'
+  gem 'activerecord'
   # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
   # Using the tag is an attempt of having a stable version to test against where we can ensure that
   # we test against the correct code.

--- a/gemfiles/Gemfile.actionpack3.2
+++ b/gemfiles/Gemfile.actionpack3.2
@@ -5,6 +5,7 @@ gemspec :path => ".."
 
 group :test do
   gem 'actionpack', '~> 3.2.0'
+  gem 'activerecord', '~> 3.2.0'
   # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
   # Using the tag is an attempt of having a stable version to test against where we can ensure that
   # we test against the correct code.

--- a/gemfiles/Gemfile.actionpack4.0
+++ b/gemfiles/Gemfile.actionpack4.0
@@ -5,6 +5,7 @@ gemspec :path => ".."
 
 group :test do
   gem 'actionpack', '~> 4.0.0'
+  gem 'activerecord', '~> 4.0.0'
   # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
   # Using the tag is an attempt of having a stable version to test against where we can ensure that
   # we test against the correct code.

--- a/gemfiles/Gemfile.actionpack4.2
+++ b/gemfiles/Gemfile.actionpack4.2
@@ -5,6 +5,8 @@ gemspec :path => ".."
 
 group :test do
   gem 'actionpack', '~> 4.2.0'
+  gem 'activerecord', '~> 4.2.0'
+
   # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
   # Using the tag is an attempt of having a stable version to test against where we can ensure that
   # we test against the correct code.

--- a/lib/lograge/log_subscriber.rb
+++ b/lib/lograge/log_subscriber.rb
@@ -1,5 +1,4 @@
 require 'json'
-
 require 'active_support/core_ext/class/attribute'
 require 'active_support/log_subscriber'
 
@@ -10,7 +9,7 @@ module Lograge
 
       payload = event.payload
 
-      data      = extract_request(payload)
+      data = extract_request(payload)
       extract_status(data, payload)
       runtimes(data, event)
       location(data)
@@ -62,11 +61,17 @@ module Lograge
         data[:status] = status.to_i
       elsif (error = payload[:exception])
         exception, message = error
-        data[:status] = 500
-        data[:error]  = "#{exception}:#{message}"
+        data[:status] = get_error_status_code(exception)
+        data[:error] = "#{exception}: #{message}"
       else
         data[:status] = 0
       end
+    end
+
+    def get_error_status_code(exception)
+      exception_object = exception.constantize.new
+      exception_wrapper = ::ActionDispatch::ExceptionWrapper.new({}, exception_object)
+      exception_wrapper.status_code
     end
 
     def custom_options(data, event)


### PR DESCRIPTION
This is an attempt/proposal to fix #110 and parts of #27.
It will correctly log an `ActiveRecord::RecordNotFound` as a 404 and other things coming back from AR and others.

It will however not log a `ActionController::RoutingError` as this is out of reach with the current implementation. See the referenced issues for this.