### PR TITLE
Remove Rubinius from allowed failures list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
   allow_failures:
     - rvm: jruby
     - rvm: jruby-head
-    - rvm: rbx-2
 gemfile:
   - Gemfile
   - gemfiles/Gemfile.actionpack3.2


### PR DESCRIPTION
As the bug that made issues here: https://github.com/roidrage/lograge/pull/121 is fixed in the latest release we can remove RBX again from the allowed failures.

The JRuby builds are also fine again. Should we do the same there?