### PR TITLE
Add ability to use Rails Initializer file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 * Resolves build failures under rails 3.2 caused by `logstash-event` dependency
+* Delay loading so `config.enabled=` works from `config/initializers/*.rb` (<https://github.com/allori>) #62
 
 ## 0.3.2
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ In your Gemfile
 gem "lograge"
 ```
 
-Enable it for the relevant environments, e.g. production:
+Enable it in an initializer or the relevant environment config:
 
 ```ruby
+# config/initializers/lograge.rb
+# OR
 # config/environments/production.rb
 MyApp::Application.configure do
   config.lograge.enabled = true

--- a/lib/lograge/railtie.rb
+++ b/lib/lograge/railtie.rb
@@ -7,7 +7,7 @@ module Lograge
     config.lograge = ActiveSupport::OrderedOptions.new
     config.lograge.enabled = false
 
-    initializer :lograge do |app|
+    config.after_initialize do |app|
       Lograge.setup(app) if app.config.lograge.enabled
     end
   end


### PR DESCRIPTION
Fixes issue #62.

This patch allows config.lograge.* to be set effectively in
config/initializers/* by delaying the Railtie until
after_initialize.

Because Railtie initializers run before those app initializers,
and the Lograge initializer loads the system only if
config.enabled is set at the time it runs, changing config.lograge
in config/initializers/* was previously ineffective.