### PR TITLE
Don't attempt to create exception classes

### DIFF
--- a/lib/lograge/log_subscriber.rb
+++ b/lib/lograge/log_subscriber.rb
@@ -69,9 +69,8 @@ module Lograge
     end
 
     def get_error_status_code(exception)
-      exception_object = exception.constantize.new
-      exception_wrapper = ::ActionDispatch::ExceptionWrapper.new({}, exception_object)
-      exception_wrapper.status_code
+      status = ActionDispatch::ExceptionWrapper.rescue_responses[exception]
+      Rack::Utils.status_code(status)
     end
 
     def custom_options(data, event)


### PR DESCRIPTION
This resolves #126 by not attempting to create exception classes. A
couple of points no less:

1. The `ActiveRecord` specific exceptions _are_ loaded and merged when
its railtie is loaded. Our tests do not load `ActiveRecord` so while
they don't exist in our context, they _will_ be around in your garden
variety rails application.
2. We essentially replicate what the `ExceptionWrapper` was doing for
us, but by leveraging `Rack::Utils.status_code` we avoid the need to
create an instance of the actual exception class. Thus avoiding the
problems experienced creating exceptions that expect initializer
arguments.