### PR TITLE
An alternative to the "append_info_to_payload" strategy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ rvm:
   - 2.3.3
   - jruby-9.1.6.0
   - jruby-head
-before_install: gem install bundler
+before_install:
+  - gem update --system
+  - gem install bundler
 matrix:
   fast_finish: true
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -123,11 +123,10 @@ This hash is merged into the log data automatically.
 MyApp::Application.configure do
   config.lograge.enabled = true
 
-  # custom_payload must be a proc that returns a hash
-  config.lograge.custom_payload = proc do
+  config.lograge.custom_payload do |controller|
     {
-      host: request.host,
-      user_id: current_user.try(:id)
+      host: controller.request.host,
+      user_id: controller.current_user.try(:id)
     }
   end
 end

--- a/README.md
+++ b/README.md
@@ -116,6 +116,23 @@ class ApplicationController < ActionController::Base
 end
 ```
 
+Alternatively, you can add a hook for accessing controller methods directly (e.g. `request` and `current_user`).
+This hash is merged into the log data automatically.
+
+```ruby
+MyApp::Application.configure do
+  config.lograge.enabled = true
+
+  # custom_payload must be a proc that returns a hash
+  config.lograge.custom_payload = proc do
+    {
+      host: request.host,
+      user_id: current_user.try(:id)
+    }
+  end
+end
+```
+
 To further clean up your logging, you can also tell Lograge to skip log messages
 meeting given criteria.  You can skip log messages generated from certain controller
 actions, or you can write a custom handler to skip messages based on data in the log event:

--- a/lib/lograge.rb
+++ b/lib/lograge.rb
@@ -9,9 +9,9 @@ require 'lograge/formatters/logstash'
 require 'lograge/formatters/ltsv'
 require 'lograge/formatters/raw'
 require 'lograge/log_subscriber'
+require 'lograge/ordered_options'
 require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/core_ext/string/inflections'
-require 'active_support/ordered_options'
 
 # rubocop:disable ModuleLength
 module Lograge
@@ -143,13 +143,13 @@ module Lograge
   end
 
   def setup_custom_payload
-    return unless lograge_config.custom_payload.respond_to?(:call)
+    return unless lograge_config.custom_payload_method.respond_to?(:call)
     append_payload_method = ActionController::Base.instance_method(:append_info_to_payload)
-    custom_payload_method = lograge_config.custom_payload
+    custom_payload_method = lograge_config.custom_payload_method
 
     ActionController::Base.send(:define_method, :append_info_to_payload) do |payload|
       append_payload_method.bind(self).call(payload)
-      payload[:custom_payload] = instance_eval(&custom_payload_method)
+      payload[:custom_payload] = custom_payload_method.call(self)
     end
   end
 

--- a/lib/lograge/log_subscriber.rb
+++ b/lib/lograge/log_subscriber.rb
@@ -83,7 +83,8 @@ module Lograge
     end
 
     def custom_options(event)
-      Lograge.custom_options(event) || {}
+      options = Lograge.custom_options(event) || {}
+      options.merge event.payload[:custom_payload] || {}
     end
 
     def before_format(data, payload)

--- a/lib/lograge/ordered_options.rb
+++ b/lib/lograge/ordered_options.rb
@@ -1,0 +1,9 @@
+require 'active_support/ordered_options'
+
+module Lograge
+  class OrderedOptions < ActiveSupport::OrderedOptions
+    def custom_payload(&block)
+      self.custom_payload_method = block
+    end
+  end
+end

--- a/lib/lograge/railtie.rb
+++ b/lib/lograge/railtie.rb
@@ -4,7 +4,7 @@ require 'action_controller/log_subscriber'
 
 module Lograge
   class Railtie < Rails::Railtie
-    config.lograge = ActiveSupport::OrderedOptions.new
+    config.lograge = Lograge::OrderedOptions.new
     config.lograge.enabled = false
 
     config.after_initialize do |app|

--- a/spec/lograge_logsubscriber_spec.rb
+++ b/spec/lograge_logsubscriber_spec.rb
@@ -233,6 +233,26 @@ describe Lograge::RequestLogSubscriber do
     end
   end
 
+  context 'when event payload includes a "custom_payload"' do
+    before do
+      Lograge.formatter = Lograge::Formatters::KeyValue.new
+    end
+
+    it 'incorporates the payload correctly' do
+      event.payload[:custom_payload] = { data: 'value' }
+
+      subscriber.process_action(event)
+      expect(log_output.string).to match(/ data=value/)
+    end
+
+    it 'works when custom_payload is nil' do
+      event.payload[:custom_payload] = nil
+
+      subscriber.process_action(event)
+      expect(log_output.string).to be_present
+    end
+  end
+
   context 'with before_format configured for lograge output' do
     before do
       Lograge.formatter = Lograge::Formatters::KeyValue.new

--- a/spec/lograge_spec.rb
+++ b/spec/lograge_spec.rb
@@ -94,15 +94,14 @@ describe Lograge do
 
   describe 'handling custom_payload option' do
     let(:app_config) do
-      double(config:
-              ActiveSupport::OrderedOptions.new.tap do |config|
-                config.action_dispatch = double(rack_cache: false)
-                config.lograge = Lograge::OrderedOptions.new
-                config.lograge.custom_payload do |c|
-                  { user_id: c.current_user_id }
-                end
-              end
-            )
+      config_obj = ActiveSupport::OrderedOptions.new.tap do |config|
+        config.action_dispatch = double(rack_cache: false)
+        config.lograge = Lograge::OrderedOptions.new
+        config.lograge.custom_payload do |c|
+          { user_id: c.current_user_id }
+        end
+      end
+      double(config: config_obj)
     end
     let(:controller) do
       Class.new do

--- a/spec/lograge_spec.rb
+++ b/spec/lograge_spec.rb
@@ -108,21 +108,23 @@ describe Lograge do
         def append_info_to_payload(payload)
           payload.merge!(appended: true)
         end
+
+        def current_user_id
+          '24601'
+        end
       end
     end
-    let(:user_id) { '24601' }
     let(:payload) { { timestamp: Date.parse('5-11-1955') } }
 
     subject { payload.dup }
 
     before do
-      controller.any_instance.stub(:current_user_id).and_return(user_id)
       stub_const('ActionController::Base', controller)
       Lograge.setup(app_config)
       ActionController::Base.new.append_info_to_payload(subject)
     end
 
-    it { should eq(payload.merge(appended: true, custom_payload: { user_id: user_id })) }
+    it { should eq(payload.merge(appended: true, custom_payload: { user_id: '24601' })) }
   end
 
   describe 'deprecated log_format interpreter' do

--- a/spec/lograge_spec.rb
+++ b/spec/lograge_spec.rb
@@ -97,8 +97,10 @@ describe Lograge do
       double(config:
               ActiveSupport::OrderedOptions.new.tap do |config|
                 config.action_dispatch = double(rack_cache: false)
-                config.lograge = ActiveSupport::OrderedOptions.new
-                config.lograge.custom_payload = proc { { user_id: current_user_id } }
+                config.lograge = Lograge::OrderedOptions.new
+                config.lograge.custom_payload do |c|
+                  { user_id: c.current_user_id }
+                end
               end
             )
     end


### PR DESCRIPTION
This is a solution relating to #94. It started more as a proof-of-concept, but I ended up reworking it a little and writing tests, so it might be useful for you, depending on whether the pain point is actually worth solving.

Essentially, this combines the `custom_payload` option and the `append_info_to_payload` method override strategy (see #94) into a single config option that looks like this:

``` ruby
MyApp::Application.configure do
  config.lograge.enabled = true

  # custom_payload must be a proc that returns a hash
  config.lograge.custom_payload = proc do
    {
      host: request.host,
      user_id: current_user.try(:id),
      fwd: request.remote_ip
    }
  end
end
```

Unfortunately, because of the way that the logging instrumentation uses an `ActiveSupport::Notification` event to pass the payload through to lograge, I had to perform a bit of magic to get this working. (Notice how  `request` and `current_user` are magically accessible from within the proc.)

Also, I chose to create a new config (`custom_payload`) rather than change the behavior of the existing config (`custom_options`) because the two approaches are not really comparable.

I'd be open to re-implementing this with a bit less magic. Let me know what you think.
