### PR TITLE
Made readme clearer on additional rails logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ MyApp::Application.configure do
 end
 ```
 
-You can then add custom variables to the event to be used in `custom_options` (available via the `event.payload` hash)
+You can then add custom variables to the event to be used in `custom_options` (available via the `event.payload` hash, which has to be processed in `custom_options` method to be included in log output, see above):
 
 ```ruby
 # app/controllers/application_controller.rb


### PR DESCRIPTION
The `append_info_to_payload` example now states more clearely that the additional data also needs to be processed by the `custom_options` method.

This was one thing which took me more than one try to get right. I only searched the readme for rails and added the part for `application_controller.rb` without looking above.