### PR TITLE
Pessimistically lock `rubocop`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,5 @@ group :test do
   # logstash 1.5.4 is only supported with jrjackson up to  0.2.9
   gem 'jrjackson', '0.2.9', platforms: :jruby
   gem 'lines'
-  gem 'rubocop'
+  gem 'rubocop', '~> 0.35'
 end


### PR DESCRIPTION
Let's make sure we are pinned to the correct minor version for rubucop.
There were examples of rubocop being bumped in previous builds and
introducing breaking changes to our ruleset.