### PR TITLE
Log unpermitted parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### Unreleased
+
+* Support logging of unpermitted parameters in Rails 4+ #154
+
 ### 0.3.4
 
 * Added LTSV formatter (<https://github.com/takashi>) #138

--- a/lib/lograge/log_subscriber.rb
+++ b/lib/lograge/log_subscriber.rb
@@ -14,6 +14,7 @@ module Lograge
       extract_status(data, payload)
       runtimes(data, event)
       location(data)
+      unpermitted(data)
       custom_options(data, event)
 
       data = before_format(data, payload)
@@ -23,6 +24,11 @@ module Lograge
 
     def redirect_to(event)
       Thread.current[:lograge_location] = event.payload[:location]
+    end
+
+    def unpermitted_parameters(event)
+      Thread.current[:lograge_unpermitted_params] ||= []
+      Thread.current[:lograge_unpermitted_params].concat(event.payload[:keys])
     end
 
     def logger
@@ -96,6 +102,14 @@ module Lograge
 
       Thread.current[:lograge_location] = nil
       data[:location] = location
+    end
+
+    def unpermitted(data)
+      unpermitted_params = Thread.current[:lograge_unpermitted_params]
+      return unless unpermitted_params
+
+      Thread.current[:lograge_unpermitted_params] = nil
+      data[:unpermitted_params] = unpermitted_params
     end
   end
 end

--- a/spec/lograge_logsubscriber_spec.rb
+++ b/spec/lograge_logsubscriber_spec.rb
@@ -29,16 +29,6 @@ describe Lograge::RequestLogSubscriber do
       view_runtime: 0.01
     )
   end
-  let(:redirect) do
-    ActiveSupport::Notifications::Event.new(
-      'redirect_to.action_controller',
-      Time.now,
-      Time.now,
-      1,
-      location: 'http://example.com',
-      status: 302
-    )
-  end
 
   before { Lograge.logger = logger }
 
@@ -69,8 +59,19 @@ describe Lograge::RequestLogSubscriber do
   end
 
   context 'when processing a redirect' do
+    let(:redirect_event) do
+      ActiveSupport::Notifications::Event.new(
+        'redirect_to.action_controller',
+        Time.now,
+        Time.now,
+        1,
+        location: 'http://example.com',
+        status: 302
+      )
+    end
+
     it 'stores the location in a thread local variable' do
-      subscriber.redirect_to(redirect)
+      subscriber.redirect_to(redirect_event)
       expect(Thread.current[:lograge_location]).to eq('http://example.com')
     end
   end


### PR DESCRIPTION
Fixes #152.
This will only log if `config.action_controller.action_on_unpermitted_parameters = :log`.
This PR also refactors LogSubscriber to make rubocop happy.

