### PR TITLE
Fixes console for local development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in lograge.gemspec
 gemspec
 
+gem 'pry', group: :development
+
 group :test do
   gem 'actionpack'
   gem 'activerecord'

--- a/tools/console
+++ b/tools/console
@@ -2,7 +2,7 @@
 
 require 'pathname'
 
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', Pathname.new(__FILE__).realpath)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', File.dirname(__FILE__))
 
 require 'rubygems'
 require 'bundler/setup'


### PR DESCRIPTION
Prior to this, resolving `BUNDLE_GEMFILE` was problematic plus we were
relying on the user having `pry` installed globally. Which may not be
the case.