### PR TITLE
Replace `2.2.3` with `2.3.0` in travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundle
 sudo: false
 rvm:
   - 1.9.3
-  - 2.2.3
+  - 2.3.0
   - jruby
   - jruby-head
   - rbx-2


### PR DESCRIPTION
Build against `2.3.0` given it's the latest released version as of the
current time.