### PR TITLE
fix LTSV formatter to split by hard tab not string '\t'

### DIFF
--- a/lib/lograge/formatters/ltsv.rb
+++ b/lib/lograge/formatters/ltsv.rb
@@ -5,7 +5,7 @@ module Lograge
         fields = fields_to_display(data)
 
         event = fields.map { |key| format(key, data[key]) }
-        event.join('\t')
+        event.join("\t")
       end
 
       def fields_to_display(data)

--- a/spec/formatters/ltsv_spec.rb
+++ b/spec/formatters/ltsv_spec.rb
@@ -25,7 +25,7 @@ describe Lograge::Formatters::LTSV do
     expect(subject).to include('will_escaped:\\t')
   end
 
-  it 'should be splitted by tab' do
+  it 'is separated by hard tabs' do
     expect(subject.split("\t").count).to eq(payload.count)
   end
 end

--- a/spec/formatters/ltsv_spec.rb
+++ b/spec/formatters/ltsv_spec.rb
@@ -24,4 +24,8 @@ describe Lograge::Formatters::LTSV do
   it 'escapes escape sequences as value' do
     expect(subject).to include('will_escaped:\\t')
   end
+
+  it 'should be splitted by tab' do
+    expect(subject.split("\t").count).to eq(payload.count)
+  end
 end


### PR DESCRIPTION
Hello,

I found LTSV formatter split values by string '\t' not hard tab.
I fixed it and write some spec.

Thanks.