### PR TITLE
Pin rubocop and parser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,4 @@ group :test do
   # logstash 1.5.4 is only supported with jrjackson up to  0.2.9
   gem 'jrjackson', '0.2.9', platforms: :jruby
   gem 'lines'
-  gem 'rubocop', '~> 0.35'
 end

--- a/gemfiles/Gemfile.actionpack3.2
+++ b/gemfiles/Gemfile.actionpack3.2
@@ -15,8 +15,5 @@ group :test do
   gem 'jrjackson', '0.2.9', platforms: :jruby
   # thread_save is a logstash dependency
   gem 'thread_safe', '0.3.5'
-
-
   gem 'lines'
-  gem 'rubocop'
 end

--- a/gemfiles/Gemfile.actionpack4.0
+++ b/gemfiles/Gemfile.actionpack4.0
@@ -14,5 +14,4 @@ group :test do
   # logstash 1.5.4 is only supported with jrjackson up to  0.2.9
   gem 'jrjackson', '0.2.9', platforms: :jruby
   gem 'lines'
-  gem 'rubocop'
 end

--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -13,6 +13,9 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files lib`.split("\n")
 
   s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rubocop', '0.35.1'
+  s.add_development_dependency 'parser', '2.3.0.2'
+
   s.add_runtime_dependency 'activesupport', '>= 3'
   s.add_runtime_dependency 'actionpack', '>= 3'
   s.add_runtime_dependency 'railties', '>= 3'


### PR DESCRIPTION
Pins rubocop and parser reliably. Prior to this change and despite
previously pinning rubocop in the `Gemfile`, recent CI builds were
failing since rubocop was being installed at `0.37`.

This change moves the rubocop dependency to the development dependencies
in the gemspec. Unfortunately a bug in compatibility between parser and
rubocop meant I also needed to pin parser at a specific version.

I'll bring us up to the latest rubocop soon and undo this work.