### PR TITLE
Add support for Rails `5.0.0.beta2`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundle
 sudo: false
 rvm:
   - 2.3.0
-  - jruby
+  - jruby-9.0.4.0
   - jruby-head
   - rbx-2
 matrix:
@@ -16,4 +16,5 @@ env:
 gemfile:
   - Gemfile
   - gemfiles/Gemfile.actionpack4.0
+  - gemfiles/Gemfile.actionpack5.0.0.beta2
 script: bundle exec rake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+* Add support for Rails 5 beta 2 [#166](https://github.com/roidrage/lograge/pull/166)
 * End support for Ruby 1.9.3 and Rails 3 #164
 
 ### 0.3.6

--- a/gemfiles/Gemfile.actionpack5.0.0.beta2
+++ b/gemfiles/Gemfile.actionpack5.0.0.beta2
@@ -1,13 +1,12 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in lograge.gemspec
-gemspec
-
-gem 'pry', group: :development
+gemspec path: '..'
 
 group :test do
-  gem 'actionpack', '4.2.5.1'
-  gem 'activerecord', '4.2.5.1'
+  gem 'activerecord', '5.0.0.beta2'
+  gem 'actionpack', '5.0.0.beta2'
+
   # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
   # Using the tag is an attempt of having a stable version to test against where we can ensure that
   # we test against the correct code.

--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '0.35.1'
   s.add_development_dependency 'parser', '2.3.0.2'
 
-  s.add_runtime_dependency 'activesupport', '>= 4'
-  s.add_runtime_dependency 'actionpack', '>= 4'
-  s.add_runtime_dependency 'railties', '>= 4'
+  s.add_runtime_dependency 'activesupport', '>= 4', '<= 5.0.0.beta2'
+  s.add_runtime_dependency 'actionpack', '>= 4', '<= 5.0.0.beta2'
+  s.add_runtime_dependency 'railties', '>= 4', '<= 5.0.0.beta2'
 end

--- a/spec/lograge_logsubscriber_spec.rb
+++ b/spec/lograge_logsubscriber_spec.rb
@@ -2,7 +2,7 @@ require 'lograge/log_subscriber'
 require 'active_support/notifications'
 require 'active_support/core_ext/string'
 require 'logger'
-require 'active_record/errors'
+require 'active_record'
 require 'rails'
 
 describe Lograge::RequestLogSubscriber do


### PR DESCRIPTION
Thankfully, Rails 5 support was simply a drop-in change.

Testing this in a basic sample application yields the expected results.