### PR TITLE
Release `0.4.0.pre`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ### Unreleased
 
+### 0.4.0.pre
+
 * Add support for Rails 5 beta 2 [#166](https://github.com/roidrage/lograge/pull/166)
-* End support for Ruby 1.9.3 and Rails 3 #164
+* End support for Ruby 1.9.3 and Rails 3 [#164](https://github.com/roidrage/lograge/pull/164)
 
 ### 0.3.6
 

--- a/lib/lograge/version.rb
+++ b/lib/lograge/version.rb
@@ -1,3 +1,3 @@
 module Lograge
-  VERSION = '0.3.6'
+  VERSION = '0.4.0.pre'
 end


### PR DESCRIPTION
* Drop support for Ruby 1.9.3 and Rails 3.2.
* Add support for Rails 5 beta 2.