### PR TITLE
Bump rubocop and fix new violations

### DIFF
--- a/lib/lograge/formatters/key_value.rb
+++ b/lib/lograge/formatters/key_value.rb
@@ -18,9 +18,8 @@ module Lograge
           # Parsing this can be ambigious if the error messages contains
           # a single quote
           value = "'#{value}'"
-        else
-          # Ensure that we always have exactly two decimals
-          value = Kernel.format('%.2f', value) if value.is_a? Float
+        elsif value.is_a? Float
+          value = Kernel.format('%.2f', value)
         end
 
         "#{key}=#{value}"

--- a/lib/lograge/formatters/l2met.rb
+++ b/lib/lograge/formatters/l2met.rb
@@ -4,9 +4,17 @@ module Lograge
   module Formatters
     class L2met < KeyValue
       L2MET_FIELDS = [
-        :method, :path, :format, :source, :status, :error,
-        :duration, :view, :db, :location
-      ]
+        :method,
+        :path,
+        :format,
+        :source,
+        :status,
+        :error,
+        :duration,
+        :view,
+        :db,
+        :location
+      ].freeze
 
       def call(data)
         super(modify_payload(data))

--- a/lib/lograge/formatters/ltsv.rb
+++ b/lib/lograge/formatters/ltsv.rb
@@ -18,9 +18,8 @@ module Lograge
           # Parsing this can be ambigious if the error messages contains
           # a single quote
           value = "'#{escape value}'"
-        else
-          # Ensure that we always have exactly two decimals
-          value = Kernel.format('%.2f', value) if value.is_a? Float
+        elsif value.is_a? Float
+          value = Kernel.format('%.2f', value)
         end
 
         "#{key}:#{value}"

--- a/lib/lograge/version.rb
+++ b/lib/lograge/version.rb
@@ -1,3 +1,3 @@
 module Lograge
-  VERSION = '0.4.0.pre2'
+  VERSION = '0.4.0.pre2'.freeze
 end

--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -10,11 +10,10 @@ Gem::Specification.new do |s|
   s.description = "Tame Rails' multi-line logging into a single line per request"
   s.license     = 'MIT'
 
-  s.files         = `git ls-files lib`.split("\n")
+  s.files = `git ls-files lib`.split("\n")
 
   s.add_development_dependency 'rspec'
-  s.add_development_dependency 'rubocop', '0.35.1'
-  s.add_development_dependency 'parser', '2.3.0.2'
+  s.add_development_dependency 'rubocop', '0.37.2'
 
   s.add_runtime_dependency 'activesupport', '>= 4', '<= 5.0.0.beta3'
   s.add_runtime_dependency 'actionpack', '>= 4', '<= 5.0.0.beta3'


### PR DESCRIPTION
This meant we could also unpin parser as the transitive dependency via rubocop
is happier.