### PR TITLE
Loosens Rails version requirement on 5.0.0

### DIFF
--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop', '0.37.2'
 
-  s.add_runtime_dependency 'activesupport', '>= 4', '<= 5.0.0'
-  s.add_runtime_dependency 'actionpack',    '>= 4', '<= 5.0.0'
-  s.add_runtime_dependency 'railties',      '>= 4', '<= 5.0.0'
+  s.add_runtime_dependency 'activesupport', '>= 4'
+  s.add_runtime_dependency 'actionpack',    '>= 4'
+  s.add_runtime_dependency 'railties',      '>= 4'
 end


### PR DESCRIPTION
The current constraint will require an update to lograge when Rails
5.0.1 is released. Previous versions of lograge only required a minimum
version and that appears to have worked out well. Given that, and the
stability of the internal Rails API, it's likely fine to just expect a
minimum version.