### PR TITLE
Update README and spec for v0.4.0 or later (ref #172)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Completed 200 OK in 79ms (Views: 78.8ms | ActiveRecord: 0.0ms)
 you get a single line with all the important information, like this:
 
 ```
-method=GET path=/jobs/833552.json format=json controller=jobs action=show status=200 duration=58.33 view=40.43 db=15.26
+method=GET path=/jobs/833552.json format=json controller=JobsController  action=show status=200 duration=58.33 view=40.43 db=15.26
 ```
 
 The second line is easy to grasp with a single glance and still includes all the
@@ -125,7 +125,7 @@ actions, or you can write a custom handler to skip messages based on data in the
 MyApp::Application.configure do
   config.lograge.enabled = true
 
-  config.lograge.ignore_actions = ['home#index', 'aController#anAction']
+  config.lograge.ignore_actions = ['HomeController#index', 'AController#an_action']
   config.lograge.ignore_custom = lambda do |event|
     # return true here if you want to ignore based on the event
   end

--- a/spec/lograge_logsubscriber_spec.rb
+++ b/spec/lograge_logsubscriber_spec.rb
@@ -21,7 +21,7 @@ describe Lograge::RequestLogSubscriber do
       Time.now,
       2,
       status: 200,
-      controller: 'home',
+      controller: 'HomeController',
       action: 'index',
       format: 'application/json',
       method: 'GET',
@@ -122,7 +122,7 @@ describe Lograge::RequestLogSubscriber do
 
     it 'includes the controller and action' do
       subscriber.process_action(event)
-      expect(log_output.string).to include('controller=home action=index')
+      expect(log_output.string).to include('controller=HomeController action=index')
     end
 
     it 'includes the duration' do
@@ -261,7 +261,7 @@ describe Lograge::RequestLogSubscriber do
     end
 
     it 'does not log ignored controller actions given a single ignored action' do
-      Lograge.ignore_actions 'home#index'
+      Lograge.ignore_actions 'HomeController#index'
       subscriber.process_action(event)
       expect(log_output.string).to be_blank
     end
@@ -269,25 +269,25 @@ describe Lograge::RequestLogSubscriber do
     it 'does not log ignored controller actions given a single ignored action after a custom ignore' do
       Lograge.ignore(->(_event) { false })
 
-      Lograge.ignore_actions 'home#index'
+      Lograge.ignore_actions 'HomeController#index'
       subscriber.process_action(event)
       expect(log_output.string).to be_blank
     end
 
     it 'logs non-ignored controller actions given a single ignored action' do
-      Lograge.ignore_actions 'foo#bar'
+      Lograge.ignore_actions 'FooController#bar'
       subscriber.process_action(event)
       expect(log_output.string).to be_present
     end
 
     it 'does not log ignored controller actions given multiple ignored actions' do
-      Lograge.ignore_actions ['foo#bar', 'home#index', 'bar#foo']
+      Lograge.ignore_actions ['FooController#bar', 'HomeController#index', 'BarController#foo']
       subscriber.process_action(event)
       expect(log_output.string).to be_blank
     end
 
     it 'logs non-ignored controller actions given multiple ignored actions' do
-      Lograge.ignore_actions ['foo#bar', 'bar#foo']
+      Lograge.ignore_actions ['FooController#bar', 'BarController#foo']
       subscriber.process_action(event)
       expect(log_output.string).to_not be_blank
     end


### PR DESCRIPTION
`payload[:controller]` of event stores the class name of controller.
http://api.rubyonrails.org/v4.2.6/classes/ActiveSupport/Notifications.html