### PR TITLE
Call log_process_action so that we get status code from Devise controllers

### DIFF
--- a/lib/lograge/log_subscriber.rb
+++ b/lib/lograge/log_subscriber.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'action_pack'
+require 'action_controller'
 require 'active_support/core_ext/class/attribute'
 require 'active_support/log_subscriber'
 
@@ -9,6 +10,7 @@ module Lograge
       return if Lograge.ignore?(event)
 
       payload = event.payload
+      _additions = ActionController::Base.log_process_action(payload)
       data = extract_request(event, payload)
       data = before_format(data, payload)
       formatted_message = Lograge.formatter.call(data)

--- a/spec/lograge_logsubscriber_spec.rb
+++ b/spec/lograge_logsubscriber_spec.rb
@@ -328,4 +328,13 @@ describe Lograge::RequestLogSubscriber do
 
     expect(log_output.string).to be_present
   end
+
+  context 'with a status code that is set in log_process_action (devise)' do
+    it 'returns the correct status code' do
+      allow(ActionController::Base).to receive(:log_process_action) { |payload| payload[:status] = 401 }
+      event.payload[:status] = nil
+      subscriber.process_action(event)
+      expect(log_output.string).to match(/status=401 /)
+    end
+  end
 end


### PR DESCRIPTION
As described in https://github.com/roidrage/lograge/issues/67 we're facing an issue when Devise returns a 401 status code (which is set in [`log_process_action`](https://github.com/plataformatec/devise/blob/8a4d610c587ca7d0f5ce40d9a4a28a2da717f1e9/lib/devise/controllers/helpers.rb#L80-L83).

With this change we're behaving the same as [`ActionController::LogSubscriber`](https://github.com/rails/rails/blob/912ae0b34bf541f18d051c8a274a54aef91a5e04/actionpack/lib/action_controller/log_subscriber.rb#L20). I don't really know if this qualifies as a workaround (and what the original intent behind `log_process_action` is/was).

Please also note that there's an open PR on Devise that moves the setting of the status code from `log_process_action` to `append_info_to_payload`.