### PR TITLE
Travis: use latest stable jruby in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundle
 sudo: false
 rvm:
   - 2.3.3
-  - jruby-9.1.6.0
+  - jruby-9.1.8.0
   - jruby-head
 before_install: gem install bundler
 matrix:


### PR DESCRIPTION
This PR updates CI JRuby to be latest stable release.