### PR TITLE
Support Rails 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 0.5.0
+
+* Rails 5.1 support [#208](https://github.com/roidrage/lograge/pull/208)
+
 ### 0.5.0.rc2
 
 * Rails 5.1 RC2 support [#207](https://github.com/roidrage/lograge/pull/207)

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ gemspec
 gem 'pry', group: :development
 
 group :test do
-  gem 'actionpack', '5.1.0.rc2'
-  gem 'activerecord', '5.1.0.rc2'
+  gem 'actionpack', '5.1.0'
+  gem 'activerecord', '5.1.0'
   # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
   # Using the tag is an attempt of having a stable version to test against where we can ensure that
   # we test against the correct code.

--- a/lib/lograge/version.rb
+++ b/lib/lograge/version.rb
@@ -1,3 +1,3 @@
 module Lograge
-  VERSION = '0.5.0.rc2'.freeze
+  VERSION = '0.5.0'.freeze
 end

--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop', '0.46.0'
 
-  s.add_runtime_dependency 'activesupport', '>= 4', '<= 5.1.0.rc2'
-  s.add_runtime_dependency 'actionpack',    '>= 4', '<= 5.1.0.rc2'
-  s.add_runtime_dependency 'railties',      '>= 4', '<= 5.1.0.rc2'
+  s.add_runtime_dependency 'activesupport', '>= 4', '<= 5.1.0'
+  s.add_runtime_dependency 'actionpack',    '>= 4', '<= 5.1.0'
+  s.add_runtime_dependency 'railties',      '>= 4', '<= 5.1.0'
 end


### PR DESCRIPTION
Rails 5.1 release has been officially cut http://weblog.rubyonrails.org/2017/4/27/Rails-5-1-final/