### PR TITLE
relax rails dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ gemspec
 gem 'pry', group: :development
 
 group :test do
-  gem 'actionpack', '5.1.0'
-  gem 'activerecord', '5.1.0'
+  gem 'actionpack', '5.1.1'
+  gem 'activerecord', '5.1.1'
   # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
   # Using the tag is an attempt of having a stable version to test against where we can ensure that
   # we test against the correct code.

--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop', '0.46.0'
 
-  s.add_runtime_dependency 'activesupport', '>= 4', '<= 5.1.0'
-  s.add_runtime_dependency 'actionpack',    '>= 4', '<= 5.1.0'
-  s.add_runtime_dependency 'railties',      '>= 4', '<= 5.1.0'
+  s.add_runtime_dependency 'activesupport', '>= 4', '< 5.2'
+  s.add_runtime_dependency 'actionpack',    '>= 4', '< 5.2'
+  s.add_runtime_dependency 'railties',      '>= 4', '< 5.2'
 end


### PR DESCRIPTION
The dependencies for Rails 5.1 are too strict. This is going to require a new release when > 5.1.0 is released