### PR TITLE
Travis: jruby-9.1.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundle
 sudo: false
 rvm:
   - 2.4.1
-  - jruby-9.1.10.0
+  - jruby-9.1.12.0
   - jruby-head
 before_install: gem install bundler
 matrix:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/06/15/jruby-9-1-12-0.html