### PR TITLE
feature: Use warn and error logger levels for 4xx and 5xx statuses

### DIFF
--- a/lib/lograge/log_subscriber.rb
+++ b/lib/lograge/log_subscriber.rb
@@ -12,7 +12,8 @@ module Lograge
       data = extract_request(event, payload)
       data = before_format(data, payload)
       formatted_message = Lograge.formatter.call(data)
-      logger.send(Lograge.log_level, formatted_message)
+      logger_level = extract_logger_level(payload)
+      logger.send(logger_level, formatted_message)
     end
 
     def redirect_to(event)
@@ -111,6 +112,17 @@ module Lograge
 
       Thread.current[:lograge_unpermitted_params] = nil
       { unpermitted_params: unpermitted_params }
+    end
+
+    def extract_logger_level(payload)
+      case payload[:status]
+      when 400..499
+        'warn'
+      when 500..599
+        'error'
+      else
+        Lograge.log_level
+      end
     end
   end
 end

--- a/spec/lograge_logsubscriber_spec.rb
+++ b/spec/lograge_logsubscriber_spec.rb
@@ -328,4 +328,30 @@ describe Lograge::RequestLogSubscriber do
 
     expect(log_output.string).to be_present
   end
+
+  describe "used logger level" do
+    context 'when status is 4XX' do
+      before do
+        event.payload[:status] = 400
+        allow(logger).to receive(:warn)
+      end
+
+      it 'calls logger.warn' do
+        subscriber.process_action(event)
+        expect(logger).to have_received(:warn)
+      end
+    end
+
+    context 'when status is 5XX' do
+      before do
+        event.payload[:status] = 500
+        allow(logger).to receive(:error)
+      end
+
+      it 'calls logger.error' do
+        subscriber.process_action(event)
+        expect(logger).to have_received(:error)
+      end
+    end
+  end
 end


### PR DESCRIPTION
When `event.payload[:status]` is 4XX or 5XX, use `warn` and `error` logger levels.