### PR TITLE
Add rails 5.1 support

### DIFF
--- a/lib/lograge/formatters/logstash.rb
+++ b/lib/lograge/formatters/logstash.rb
@@ -3,6 +3,7 @@ module Lograge
     class Logstash
       def call(data)
         load_dependencies
+        data.delete(:headers) unless data[:headers].is_a?(Hash) # NOTE: for rails 5.1 support
         event = LogStash::Event.new(data)
 
         event['message'] = "[#{data[:status]}] #{data[:method]} #{data[:path]} (#{data[:controller]}##{data[:action]})"


### PR DESCRIPTION
Since update rails 5.1 adds `ActionDispatch::Http::Headers` object to payload headers that can't be parsed and causes `Could not log "process_action.action_controller" event. IOError: not opened for reading`.  This PR fixing the issue by removing ` headers` from payload but only in the case when it's not custom user hash defined in `append_info_to_payload`. Example of payload:

```
#<LogStash::Event:0x000000065f4168
 @cancelled=false,
 @data=
  {:method=>"POST",
   :path=>"/example/stats/undefined",
   :format=>:html,
   :controller=>"example::StatsController",
   :action=>"show",
   :status=>404,
   :duration=>38.52,
   :view=>37.34,
   :db=>0.0,
   :params=>
    {"type"=>"Value",
     "timezone"=>"+02:00",
     "aggregate"=>"Count",
     "time_range"=>nil,
     "filterType"=>"and",
     "filters"=>[{"value"=>"$present"}],
     "controller"=>"example/stats",
     "action"=>"show",
     "collection"=>"undefined",
     "stat"=>{"type"=>"Value", "timezone"=>"+02:00", "aggregate"=>"Count", "time_range"=>nil, "filterType"=>"and", "filters"=>[{"value"=>"$present"}]}},
   :headers=>
    #<ActionDispatch::Http::Headers:0x007fe79c0acea0
     @req=
      #<ActionDispatch::Request:0x007fe79c049030
       @env=
        {"rack.version"=>[1, 3],
         "rack.errors"=>#<IO:<STDERR>>,
         "rack.multithread"=>true,
         "rack.multiprocess"=>false,
         "rack.run_once"=>false,
         "SCRIPT_NAME"=>"/example",
         "QUERY_STRING"=>"",
         "SERVER_PROTOCOL"=>"HTTP/1.1",
         "SERVER_SOFTWARE"=>"puma 3.9.1 Private Caller",
         "GATEWAY_INTERFACE"=>"CGI/1.2",
         "REQUEST_METHOD"=>"POST",
         "REQUEST_PATH"=>"/example/stats/undefined",
         "REQUEST_URI"=>"/example/stats/undefined",
         "HTTP_VERSION"=>"HTTP/1.1",
         "HTTP_HOST"=>"example.com",
         "HTTP_USER_AGENT"=>"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.101 Safari/537.36",
         "CONTENT_LENGTH"=>"126",
         "HTTP_ACCEPT"=>"application/json, text/javascript, */*; q=0.01",
         "HTTP_ACCEPT_ENCODING"=>"gzip, deflate",
         "HTTP_ACCEPT_LANGUAGE"=>"en-US,fr;q=0.8,en;q=0.6,uk;q=0.4,ru;q=0.2",
         "HTTP_AUTHORIZATION"=> "111"
```