### PR TITLE
Travis: jruby-9.1.15.0 and skip already-taken-care-of gem update --system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ cache: bundle
 sudo: false
 rvm:
   - 2.4.1
-  - jruby-9.1.13.0
+  - jruby-9.1.14.0
   - jruby-head
 before_install:
-  - gem update --system
   - gem install bundler
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundle
 sudo: false
 rvm:
   - 2.4.1
-  - jruby-9.1.12.0
+  - jruby-9.1.13.0
   - jruby-head
 before_install:
   - gem update --system

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundle
 sudo: false
 rvm:
   - 2.4.1
-  - jruby-9.1.14.0
+  - jruby-9.1.15.0
   - jruby-head
 before_install:
   - gem install bundler


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/12/07/jruby-9-1-15-0.html

rvm does `gem system --update` in its preparatory steps.