### PR TITLE
Support custom_payload for Rails 5 API's ActionController::API

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ Rails.application.configure do
 end
 ```
 
+If you're using Rails 5's API-only mode and inherit from `ActionController::API`:
+
+```ruby
+# config/initializers/lograge.rb
+Rails.application.configure do
+  config.lograge.base_controller_class = ActionController::API
+end
+```
+
 You can also add a hook for own custom data
 
 ```ruby

--- a/lib/lograge.rb
+++ b/lib/lograge.rb
@@ -144,10 +144,11 @@ module Lograge
 
   def setup_custom_payload
     return unless lograge_config.custom_payload_method.respond_to?(:call)
-    append_payload_method = ActionController::Base.instance_method(:append_info_to_payload)
+    base_controller_class = lograge_config.base_controller_class || ActionController::Base
+    append_payload_method = base_controller_class.instance_method(:append_info_to_payload)
     custom_payload_method = lograge_config.custom_payload_method
 
-    ActionController::Base.send(:define_method, :append_info_to_payload) do |payload|
+    base_controller_class.send(:define_method, :append_info_to_payload) do |payload|
       append_payload_method.bind(self).call(payload)
       payload[:custom_payload] = custom_payload_method.call(self)
     end


### PR DESCRIPTION
[Per the Rails 5 guide](http://edgeguides.rubyonrails.org/api_app.html#creating-a-new-application), if an app is using the API-only mode then they are to have `ApplicationController` inherit from `ActionController::API` instead of `ActionController::Base`. This breaks Lograge's custom payload feature.

My PR allows the developer to set the base class so that they can switch it to `ActionController::API` or something else should their app be very specialized.