### PR TITLE
Config base_controller_class with string & constantize

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If you're using Rails 5's API-only mode and inherit from `ActionController::API`
 ```ruby
 # config/initializers/lograge.rb
 Rails.application.configure do
-  config.lograge.base_controller_class = ActionController::API
+  config.lograge.base_controller_class = 'ActionController::API'
 end
 ```
 

--- a/lib/lograge.rb
+++ b/lib/lograge.rb
@@ -144,7 +144,7 @@ module Lograge
 
   def setup_custom_payload
     return unless lograge_config.custom_payload_method.respond_to?(:call)
-    base_controller_class = lograge_config.base_controller_class || ActionController::Base
+    base_controller_class = lograge_config.base_controller_class.try(:constantize) || ActionController::Base
     append_payload_method = base_controller_class.instance_method(:append_info_to_payload)
     custom_payload_method = lograge_config.custom_payload_method
 

--- a/spec/lograge_spec.rb
+++ b/spec/lograge_spec.rb
@@ -133,7 +133,7 @@ describe Lograge do
         config_obj = ActiveSupport::OrderedOptions.new.tap do |config|
           config.action_dispatch = double(rack_cache: false)
           config.lograge = Lograge::OrderedOptions.new
-          config.lograge.base_controller_class = controller_class.constantize
+          config.lograge.base_controller_class = controller_class
           config.lograge.custom_payload do |c|
             { user_id: c.current_user_id }
           end


### PR DESCRIPTION
Makes https://github.com/roidrage/lograge/pull/227 functional

This fixes a severe problem where the controller response wasn't being returned. Something about placing the `ActionController::API` constant in the configuration block causes this.