### PR TITLE
Allow multiple base controller classes to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,23 @@ Rails.application.configure do
 end
 ```
 
-If you're using Rails 5's API-only mode and inherit from `ActionController::API`:
+If you're using Rails 5's API-only mode and inherit from
+`ActionController::API`, you must define it as the controller base class which
+lograge will patch:
 
 ```ruby
 # config/initializers/lograge.rb
 Rails.application.configure do
   config.lograge.base_controller_class = 'ActionController::API'
+end
+```
+
+If you use multiple base controller classes in your application, specify an array:
+
+```ruby
+# config/initializers/lograge.rb
+Rails.application.configure do
+  config.lograge.base_controller_class = ['ActionController::API', 'ActionController::Base']
 end
 ```
 

--- a/spec/lograge_spec.rb
+++ b/spec/lograge_spec.rb
@@ -129,11 +129,12 @@ describe Lograge do
 
     context 'when base_controller_class option is set' do
       let(:controller_class) { 'ActionController::API' }
+      let(:base_controller_class) { controller_class }
       let(:app_config) do
         config_obj = ActiveSupport::OrderedOptions.new.tap do |config|
           config.action_dispatch = double(rack_cache: false)
           config.lograge = Lograge::OrderedOptions.new
-          config.lograge.base_controller_class = controller_class
+          config.lograge.base_controller_class = base_controller_class
           config.lograge.custom_payload do |c|
             { user_id: c.current_user_id }
           end
@@ -142,6 +143,12 @@ describe Lograge do
       end
 
       it { should eq(payload.merge(appended: true, custom_payload: { user_id: '24601' })) }
+
+      context 'when base_controller_class is an array' do
+        let(:base_controller_class) { [controller_class] }
+
+        it { should eq(payload.merge(appended: true, custom_payload: { user_id: '24601' })) }
+      end
     end
   end
 


### PR DESCRIPTION
This idea came up in https://github.com/roidrage/lograge/pull/227 and since we have the exact same use case in our application, I decided to go ahead and add the feature. Here's the commit message:

> This changes the `base_controller_class` configuration option to also accept an array of class names, so that the custom payload is appended in multiple controller base classes.
> 
> Why? Because some applications have controllers that inherit from multiple base classes. Example: `ActionController::API` and `ActionController::Base`. If you have an an application with an API and also an admin panel, that would certainly be the case.
> 
> Until now, using a custom payload was only possible in the controllers that inherit from the configured `base_controller_class`. With this change, the custom payload feature can be used in all controllers -- if their base classes are set.

What do you think?