### PR TITLE
Loosen version requirements on 5.X gemfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ env:
   global:
     - JRUBY_OPTS='-J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Djruby.compile.mode=OFF -J-Djruby.compile.invokedynamic=false'
 gemfile:
-  - gemfiles/Gemfile.actionpack5.0.0
+  - gemfiles/Gemfile.actionpack5.0
   - gemfiles/Gemfile.actionpack4.0
   - Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -6,13 +6,13 @@ gemspec
 gem 'pry', group: :development
 
 group :test do
-  gem 'actionpack', '5.1.1'
-  gem 'activerecord', '5.1.1'
+  gem 'actionpack', '~> 5.1.1'
+  gem 'activerecord', '~> 5.1.1'
   # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
   # Using the tag is an attempt of having a stable version to test against where we can ensure that
   # we test against the correct code.
   gem 'logstash-event', github: 'elastic/logstash', tag: 'v1.5.4'
   # logstash 1.5.4 is only supported with jrjackson up to  0.2.9
-  gem 'jrjackson', '0.2.9', platforms: :jruby
+  gem 'jrjackson', '~> 0.2.9', platforms: :jruby
   gem 'lines'
 end

--- a/gemfiles/Gemfile.actionpack5.0
+++ b/gemfiles/Gemfile.actionpack5.0
@@ -4,14 +4,14 @@ source 'https://rubygems.org'
 gemspec path: '..'
 
 group :test do
-  gem 'activerecord', '5.0.0'
-  gem 'actionpack', '5.0.0'
+  gem 'activerecord', '~> 5.0.0'
+  gem 'actionpack', '~> 5.0.0'
 
   # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
   # Using the tag is an attempt of having a stable version to test against where we can ensure that
   # we test against the correct code.
   gem 'logstash-event', github: 'elastic/logstash', tag: 'v1.5.4'
   # logstash 1.5.4 is only supported with jrjackson up to  0.2.9
-  gem 'jrjackson', '0.2.9', platforms: :jruby
+  gem 'jrjackson', '~> 0.2.9', platforms: :jruby
   gem 'lines'
 end


### PR DESCRIPTION
This adds an additional gemfile for running Travis tests against ActiveRecord/Actionpack 5.1

It also loosens the version requirements in the 5.0 gemfile, so that you are testing against the latest patch version, instead of being pinned to `5.0.0` exactly.