### PR TITLE
Stylistic changes to key_value and l2met formatters

### DIFF
--- a/lib/lograge/formatters/key_value.rb
+++ b/lib/lograge/formatters/key_value.rb
@@ -2,27 +2,29 @@ module Lograge
   module Formatters
     class KeyValue
       def call(data)
-        fields = fields_to_display(data)
-
-        event = fields.map { |key| format(key, data[key]) }
-        event.join(' ')
+        fields_to_display(data)
+          .map { |key| format(key, data[key]) }
+          .join(' ')
       end
+
+      protected
 
       def fields_to_display(data)
         data.keys
       end
 
       def format(key, value)
-        if key == :error
-          # Exactly preserve the previous output
-          # Parsing this can be ambigious if the error messages contains
-          # a single quote
-          value = "'#{value}'"
-        elsif value.is_a? Float
-          value = Kernel.format('%.2f', value)
-        end
+        "#{key}=#{parse_value(key, value)}"
+      end
 
-        "#{key}=#{value}"
+      def parse_value(key, value)
+        # Exactly preserve the previous output
+        # Parsing this can be ambigious if the error messages contains
+        # a single quote
+        return "'#{value}'" if key == :error
+        return Kernel.format('%.2f', value) if value.is_a? Float
+
+        value
       end
     end
   end

--- a/lib/lograge/formatters/l2met.rb
+++ b/lib/lograge/formatters/l2met.rb
@@ -16,18 +16,29 @@ module Lograge
         :location
       ].freeze
 
+      UNWANTED_FIELDS = [
+        :controller,
+        :action
+      ].freeze
+
       def call(data)
         super(modify_payload(data))
+      end
+
+      protected
+
+      def fields_to_display(data)
+        L2MET_FIELDS + additional_fields(data)
+      end
+
+      def additional_fields(data)
+        (data.keys - L2MET_FIELDS) - UNWANTED_FIELDS
       end
 
       def format(key, value)
         key = "measure#page.#{key}" if value.is_a?(Float)
 
         super(key, value)
-      end
-
-      def fields_to_display(data)
-        L2MET_FIELDS + (data.keys - L2MET_FIELDS) - [:controller, :action]
       end
 
       def modify_payload(data)


### PR DESCRIPTION
Changes:
1. Internal method visibility (public -> protected)
2. Split methods a bit to improve readability and
    to allow for easier extension