### PR TITLE
No upper bound dependencies on AS/AP/Railties

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,8 @@ gemspec
 gem 'pry', group: :development
 
 group :test do
-  gem 'actionpack', '~> 5.1.1'
-  gem 'activerecord', '~> 5.1.1'
+  gem 'actionpack', '~> 5'
+  gem 'activerecord', '~> 5'
   # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
   # Using the tag is an attempt of having a stable version to test against where we can ensure that
   # we test against the correct code.

--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop', '0.46.0'
 
-  s.add_runtime_dependency 'activesupport', '>= 4', '< 5.2'
-  s.add_runtime_dependency 'actionpack',    '>= 4', '< 5.2'
-  s.add_runtime_dependency 'railties',      '>= 4', '< 5.2'
+  s.add_runtime_dependency 'activesupport', '>= 4'
+  s.add_runtime_dependency 'actionpack',    '>= 4'
+  s.add_runtime_dependency 'railties',      '>= 4'
   s.add_runtime_dependency 'request_store', '~> 1.0'
 end


### PR DESCRIPTION
These upper bound dependencies make it so that every time I go to upgrade a Rails version, I need to point to a fork of Lograge until you guys release a new version. I don't see the major benefit of having an upper bound dependency. It just creates noise/busy work for you guys. If people have issues with later versions of Rails they will report them.

In my project of ~100 gems, Lograge and 2-3 others always come up when I go to do Rails upgrades for this reason. Last time around I helped pitch in (https://github.com/roidrage/lograge/pull/208), but I think it doesn't make sense to keep doing it this way.

What do you guys think?