### PR TITLE
Strip query string from the log for Location headers

### DIFF
--- a/lib/lograge/log_subscriber.rb
+++ b/lib/lograge/log_subscriber.rb
@@ -53,6 +53,10 @@ module Lograge
 
     def extract_path(payload)
       path = payload[:path]
+      strip_query_string(path)
+    end
+
+    def strip_query_string(path)
       index = path.index('?')
       index ? path[0, index] : path
     end
@@ -104,7 +108,7 @@ module Lograge
       return {} unless location
 
       RequestStore.store[:lograge_location] = nil
-      { location: location }
+      { location: strip_query_string(location) }
     end
 
     def extract_unpermitted_params

--- a/spec/lograge_logsubscriber_spec.rb
+++ b/spec/lograge_logsubscriber_spec.rb
@@ -167,7 +167,7 @@ describe Lograge::RequestLogSubscriber do
 
     context 'with a redirect' do
       before do
-        RequestStore.store[:lograge_location] = 'http://www.example.com'
+        RequestStore.store[:lograge_location] = 'http://www.example.com?key=value'
       end
 
       it 'adds the location to the log line' do


### PR DESCRIPTION
The Location URL may contain sensitive information, so just like the path
we should remove the query string.

Closes #229