### PR TITLE
Remove unneeded payload assignation

### DIFF
--- a/lib/lograge/log_subscriber.rb
+++ b/lib/lograge/log_subscriber.rb
@@ -32,7 +32,6 @@ module Lograge
     private
 
     def extract_request(event, payload)
-      payload = event.payload
       data = initial_data(payload)
       data.merge!(extract_status(payload))
       data.merge!(extract_runtimes(event, payload))


### PR DESCRIPTION
`payload` is already given as a paramether, so there is no reason to assign it again. :bowtie:  It could be discussed if it would be better to user `event.payload` instead of assigning to a variable at all, but I think this line was just by accident here. :wink: 