### PR TITLE
Travis: jruby-9.2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 rvm:
   - 2.5
   - 2.4
-  - jruby-9.1.17.0
+  - jruby-9.2.0.0
   - jruby-head
 before_install:
   - gem install bundler


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2018/05/24/jruby-9-2-0-0.html