### PR TITLE
Add halted_callback to the log output

### DIFF
--- a/lib/lograge/log_subscriber.rb
+++ b/lib/lograge/log_subscriber.rb
@@ -16,6 +16,10 @@ module Lograge
       logger.send(Lograge.log_level, formatted_message)
     end
 
+    def halted_callback(event)
+      RequestStore.store[:lograge_halted_callback] = event.payload[:filter]
+    end
+
     def redirect_to(event)
       RequestStore.store[:lograge_location] = event.payload[:location]
     end
@@ -37,6 +41,7 @@ module Lograge
       data.merge!(extract_runtimes(event, payload))
       data.merge!(extract_location)
       data.merge!(extract_unpermitted_params)
+      data.merge!(extract_halted_callback)
       data.merge!(custom_options(event))
     end
 
@@ -116,6 +121,14 @@ module Lograge
 
       RequestStore.store[:lograge_unpermitted_params] = nil
       { unpermitted_params: unpermitted_params }
+    end
+
+    def extract_halted_callback
+      halted_callback = RequestStore.store[:lograge_halted_callback]
+      return {} unless halted_callback
+
+      RequestStore.store[:lograge_halted_callback] = nil
+      { halted_callback: halted_callback.to_s }
     end
   end
 end

--- a/spec/lograge_logsubscriber_spec.rb
+++ b/spec/lograge_logsubscriber_spec.rb
@@ -95,6 +95,23 @@ describe Lograge::RequestLogSubscriber do
     end
   end
 
+  context 'when processing halted callback' do
+    let(:halted_callback_event) do
+      ActiveSupport::Notifications::Event.new(
+        'halted_callback.action_controller',
+        Time.now,
+        Time.now,
+        1,
+        filter: :user_authenticated?
+      )
+    end
+
+    it 'stores the parameters in a thread local variable' do
+      subscriber.halted_callback(halted_callback_event)
+      expect(RequestStore.store[:lograge_halted_callback]).to eq(:user_authenticated?)
+    end
+  end
+
   context 'when processing an action with lograge output' do
     before do
       Lograge.formatter = Lograge::Formatters::KeyValue.new
@@ -205,6 +222,27 @@ describe Lograge::RequestLogSubscriber do
     it 'does not include unpermitted_params by default' do
       subscriber.process_action(event)
       expect(log_output.string).to_not include('unpermitted_params=')
+    end
+
+    context 'with halted_callback' do
+      before do
+        RequestStore.store[:lograge_halted_callback] = :user_authenticated?
+      end
+
+      it 'adds the unpermitted_params to the log line' do
+        subscriber.process_action(event)
+        expect(log_output.string).to include('halted_callback=user_authenticated?')
+      end
+
+      it 'removes the thread local variable' do
+        subscriber.process_action(event)
+        expect(RequestStore.store[:lograge_halted_callback]).to be_nil
+      end
+    end
+
+    it 'does not include unpermitted_params by default' do
+      subscriber.process_action(event)
+      expect(log_output.string).to_not include('halted_callback=')
     end
   end
 


### PR DESCRIPTION
Fix https://github.com/roidrage/lograge/issues/258

Sometimes when you do the final render or redirection, it can be halted by a controller callback. With the existing code, it can very hard to understand where it stopped. 

With this commit, the intent is to provide the method name where it stops.

I have only one rubocop offense:
```
lib/lograge/log_subscriber.rb:8:3: C: Class has too many lines. [102/100]
  class RequestLogSubscriber < ActiveSupport::LogSubscriber ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

32 files inspected, 1 offense detected
RuboCop failed!
```
What could I do? Extract all logic of `extract_runtimes`, `extract_location, `extract_unpermitted_params` and `extract_halted_callback` into separate `class`?