### PR TITLE
Change config block to use Rails.application

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Alternatively, you can add a hook for accessing controller methods directly (e.g
 This hash is merged into the log data automatically.
 
 ```ruby
-MyApp::Application.configure do
+Rails.application.configure do
   config.lograge.enabled = true
 
   config.lograge.custom_payload do |controller|


### PR DESCRIPTION
Changes:

```ruby
MyApp::Application.configure do
   ...
end
```

... to ...

```ruby
Rails.application.configure do
   ...
end
```

This is more consistent with other examples and will work without edits.