### PR TITLE
Travis: update to latest JRuby 9.2.5.0, add 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: ruby
 cache: bundle
 sudo: false
 rvm:
+  - 2.6
   - 2.5
   - 2.4
-  - jruby-9.2.0.0
+  - jruby-9.2.5.0
   - jruby-head
 before_install:
   - gem install bundler


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, 9.2.5.0.

Also adds 2.6.

[JRuby 9.2.5.0 release blog post](https://www.jruby.org/2018/12/06/jruby-9-2-5-0.html)