### PR TITLE
Add license.txt to allow for easier gem auditing

### DIFF
--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.description = "Tame Rails' multi-line logging into a single line per request"
   s.license     = 'MIT'
 
-  s.files = `git ls-files lib`.split("\n") + ["license.txt"]
+  s.files = `git ls-files lib license.txt`.split("\n")
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop', '0.46.0'

--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.description = "Tame Rails' multi-line logging into a single line per request"
   s.license     = 'MIT'
 
-  s.files = `git ls-files lib license.txt`.split("\n")
+  s.files = `git ls-files lib LICENSE.txt`.split("\n")
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop', '0.46.0'

--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.description = "Tame Rails' multi-line logging into a single line per request"
   s.license     = 'MIT'
 
-  s.files = `git ls-files lib`.split("\n")
+  s.files = `git ls-files lib`.split("\n") + ["license.txt"]
 
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop', '0.46.0'


### PR DESCRIPTION
license.txt is not included in the gem; this makes it harder to audit gem licenses.