### PR TITLE
Fix log subscriber unsubscriptions

### DIFF
--- a/lib/lograge.rb
+++ b/lib/lograge.rb
@@ -110,6 +110,8 @@ module Lograge
       ActionController::LogSubscriber.send(:subscriber)
     when 'action_view'
       ActionView::LogSubscriber.send(:subscriber)
+    when 'active_record'
+      ActiveRecord::LogSubscriber.send(:subscriber)
     end
   end
 

--- a/lib/lograge.rb
+++ b/lib/lograge.rb
@@ -95,23 +95,28 @@ module Lograge
   mattr_accessor :formatter
 
   def remove_existing_log_subscriptions
-    ActiveSupport::LogSubscriber.log_subscribers.each do |subscriber|
-      case subscriber
-      when ActionView::LogSubscriber
-        unsubscribe(:action_view, subscriber)
-      when ActionController::LogSubscriber
-        unsubscribe(:action_controller, subscriber)
-      end
+    patterns = ActiveSupport::LogSubscriber.log_subscribers.map(&:patterns).flatten.uniq
+
+    patterns.each do |pattern|
+      subscriber = subscriber_for_pattern(pattern)
+      next unless subscriber
+      unsubscribe pattern, subscriber
     end
   end
 
-  def unsubscribe(component, subscriber)
-    events = subscriber.public_methods(false).reject { |method| method.to_s == 'call' }
-    events.each do |event|
-      ActiveSupport::Notifications.notifier.listeners_for("#{event}.#{component}").each do |listener|
-        if listener.instance_variable_get('@delegate') == subscriber
-          ActiveSupport::Notifications.unsubscribe listener
-        end
+  def subscriber_for_pattern(pattern)
+    case pattern.split('.').last
+    when 'action_controller'
+      ActionController::LogSubscriber.send(:subscriber)
+    when 'action_view'
+      ActionView::LogSubscriber.send(:subscriber)
+    end
+  end
+
+  def unsubscribe(pattern, subscriber)
+    ActiveSupport::Notifications.notifier.listeners_for(pattern).each do |listener|
+      if listener.instance_variable_get('@delegate') == subscriber
+        ActiveSupport::Notifications.unsubscribe listener
       end
     end
   end


### PR DESCRIPTION
There's a bug in ActionView#public_methods(false) that makes it not returning
subscription methods. Using #patterns the log subscribed is asked directly for
its supported event names.

This becomes evident when using Lograge with a lower log level where rendering
logs render-time for each template/partial.

Also added ActiveRecord to the mix that is very noisy when using lograge in development.