### PR TITLE
Dynamic log level based on http status of request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 .bundle
+.idea
 Gemfile.lock
 gemfiles/*.lock
 pkg/*

--- a/lib/lograge.rb
+++ b/lib/lograge.rb
@@ -87,6 +87,10 @@ module Lograge
   mattr_accessor :log_level
   self.log_level = :info
 
+  # Log level may be calculated based on http status by setting map_log_level = true
+  mattr_accessor :map_log_level
+  self.map_log_level = false
+
   # The emitted log format
   #
   # Currently supported formats are>
@@ -171,6 +175,7 @@ module Lograge
     Lograge.custom_options = lograge_config.custom_options
     Lograge.before_format = lograge_config.before_format
     Lograge.log_level = lograge_config.log_level || :info
+    Lograge.map_log_level = lograge_config.map_log_level
   end
 
   def disable_rack_cache_verbose_output

--- a/lib/lograge/log_subscriber.rb
+++ b/lib/lograge/log_subscriber.rb
@@ -12,8 +12,9 @@ module Lograge
       payload = event.payload
       data = extract_request(event, payload)
       data = before_format(data, payload)
+      log_level = Lograge.map_log_level ? log_level_for_status(payload) : Lograge.log_level
       formatted_message = Lograge.formatter.call(data)
-      logger.send(Lograge.log_level, formatted_message)
+      logger.send(log_level, formatted_message)
     end
 
     def redirect_to(event)
@@ -67,6 +68,19 @@ module Lograge
     else
       def extract_format(payload)
         payload[:format]
+      end
+    end
+
+    def log_level_for_status(payload)
+      status = extract_status(payload)[:status]
+      if status < 300
+        :info
+      elsif status < 400
+        :warn
+      elsif status < 500
+        :error
+      else
+        :fatal
       end
     end
 

--- a/lib/lograge/version.rb
+++ b/lib/lograge/version.rb
@@ -1,3 +1,3 @@
 module Lograge
-  VERSION = '0.10.0'.freeze
+  VERSION = '0.11.0'.freeze
 end


### PR DESCRIPTION
Lograge is great, but I need the log level to reflect whether or not the request is processed successfully. This PR adds `Lograge.map_log_level` (default false). When `map_log_level` is set to `true`, the `Lograge.log_level` is ignored and the log level is set based on the HTTP status as:

    * status < 300 is :info
    * 300 <= status < 400  is :warn
    * 400 <= status < 500 is :error
    * status >= 500 is :fatal
