### PR TITLE
CI: Use jruby-9.2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: ruby
 cache: bundle
-sudo: false
 rvm:
   - 2.6
   - 2.5
   - 2.4
-  - jruby-9.2.5.0
+  - jruby-9.2.6.0
   - jruby-head
 before_install:
   - gem install bundler


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, 9.2.6.0.

[JRuby 9.2.6.0 release blog post](https://www.jruby.org/2019/02/11/jruby-9-2-6-0.html)

Also: drop sudo: false which now does nothing on Travis
