### PR TITLE
Revert "Update README.md (#288)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ This hash is merged into the log data automatically.
 Rails.application.configure do
   config.lograge.enabled = true
 
-  config.lograge.custom_payload_method do |controller|
+  config.lograge.custom_payload do |controller|
     {
       host: controller.request.host,
       user_id: controller.current_user.try(:id)


### PR DESCRIPTION
This reverts commit ef5f4cb8926e569c28f5e3c68d2b1d483a7f181f.

`custom_payload_method` is a variable, and the method name to setting "custom payload method" is `custom_payload`.
Anything I'm missing?

https://github.com/roidrage/lograge/blob/0e1ed0464b4be364498bb4d57ab2ae7c93eb3d59/lib/lograge/ordered_options.rb#L3-L9
