### PR TITLE
Avoid defining extract_status method twice

### DIFF
--- a/lib/lograge/log_subscribers/base.rb
+++ b/lib/lograge/log_subscribers/base.rb
@@ -32,7 +32,7 @@ module Lograge
         data.merge!(custom_options(event))
       end
 
-      %i(initial_data extract_status extract_runtimes
+      %i(initial_data extract_runtimes
          extract_location extract_unpermitted_params).each do |method_name|
         define_method(method_name) { |*_arg| {} }
       end


### PR DESCRIPTION
That method is defined 5 lines below.