### PR TITLE
CI against Rails 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,14 @@ env:
   global:
     - JRUBY_OPTS='-J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Djruby.compile.mode=OFF -J-Djruby.compile.invokedynamic=false'
 gemfile:
+  - gemfiles/Gemfile.actionpack6.0
   - gemfiles/Gemfile.actionpack5.2
   - gemfiles/Gemfile.actionpack5.1
   - gemfiles/Gemfile.actionpack5.0
   - gemfiles/Gemfile.actionpack4.0
   - Gemfile
+
+matrix:
+    exclude:
+    - rvm: 2.4
+      gemfile: gemfiles/Gemfile.actionpack6.0

--- a/gemfiles/Gemfile.actionpack6.0
+++ b/gemfiles/Gemfile.actionpack6.0
@@ -1,0 +1,17 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in lograge.gemspec
+gemspec path: '..'
+
+group :test do
+  gem 'activerecord', '~> 6.0.0'
+  gem 'actionpack', '~> 6.0.0'
+
+  # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
+  # Using the tag is an attempt of having a stable version to test against where we can ensure that
+  # we test against the correct code.
+  gem 'logstash-event', git: 'https://github.com/elastic/logstash', tag: 'v1.5.4'
+  # logstash 1.5.4 is only supported with jrjackson up to  0.2.9
+  gem 'jrjackson', '~> 0.2.9', platforms: :jruby
+  gem 'lines'
+end


### PR DESCRIPTION
* Exclude CI matrix between Ruby 2.6 and Rails 6.0
Rails 6.0 requires Ruby 2.5
  - https://github.com/rails/rails/pull/34754

No need to exclude any JRuby because "JRuby 9.2.x is compatible with Ruby 2.5.x"
  - https://www.jruby.org/2019/04/09/jruby-9-2-7-0.html