### PR TITLE
Use prepend to patch Action Cable classes

### DIFF
--- a/lib/lograge/rails_ext/action_cable/channel/base.rb
+++ b/lib/lograge/rails_ext/action_cable/channel/base.rb
@@ -1,24 +1,15 @@
 # frozen_string_literal: true
 
-module ActionCable
-  module Channel
-    class Base
+module Lograge
+  module ActionCable
+    module ChannelInstrumentation
       def subscribe_to_channel
-        ActiveSupport::Notifications.instrument('subscribe.action_cable', notification_payload('subscribe')) do
-          run_callbacks :subscribe do
-            subscribed
-          end
-
-          reject_subscription if subscription_rejected?
-          ensure_confirmation_sent
-        end
+        ActiveSupport::Notifications.instrument('subscribe.action_cable', notification_payload('subscribe')) { super }
       end
 
       def unsubscribe_from_channel
         ActiveSupport::Notifications.instrument('unsubscribe.action_cable', notification_payload('unsubscribe')) do
-          run_callbacks :unsubscribe do
-            unsubscribed
-          end
+          super
         end
       end
 
@@ -30,3 +21,5 @@ module ActionCable
     end
   end
 end
+
+ActionCable::Channel::Base.prepend(Lograge::ActionCable::ChannelInstrumentation)


### PR DESCRIPTION
To preserve the original functionality a better monkey-patching technique than copying the code should be used, e.g.,`Module#prepend`.

NOTE: The original Action Cable code for Connection class [has been already changed](https://github.com/rails/rails/blob/92d3afe4750797ef9ed639c1679bd08abc9799ac/actioncable/lib/action_cable/connection/base.rb#L171-L181), thus Lograge breaks the core functionality:

```diff
  rescue ActionCable::Connection::Authorization::UnauthorizedError
-  respond_to_invalid_request		
+  close(reason: ActionCable::INTERNAL[:disconnect_reasons][:unauthorized], reconnect: false) if websocket.alive?
  end
```

Fixes #304.
Related to #294.