### PR TITLE
Avoid version in Rack::Logger code comment

### DIFF
--- a/lib/lograge/rails_ext/rack/logger.rb
+++ b/lib/lograge/rails_ext/rack/logger.rb
@@ -9,7 +9,7 @@ module Rails
     # that say:
     # Started GET / for 192.168.2.1...
     class Logger
-      # Overwrites Rails 3.2 code that logs new requests
+      # Overwrites Rails code that logs new requests
       def call_app(*args)
         env = args.last
         @app.call(env)


### PR DESCRIPTION
This version mention could make it seem like it was no longer the case, but it is still the case, so by removing the version marker, this is less confusing.

The #before_dispatch code comment is still version-relevant, it seems.