### PR TITLE
fix: Require active_support before use

### DIFF
--- a/lib/lograge.rb
+++ b/lib/lograge.rb
@@ -16,6 +16,7 @@ require 'lograge/log_subscribers/action_cable'
 require 'lograge/log_subscribers/action_controller'
 require 'lograge/silent_logger'
 require 'lograge/ordered_options'
+require 'active_support'
 require 'active_support/core_ext/module/attribute_accessors'
 require 'active_support/core_ext/string/inflections'
 

--- a/lib/lograge/log_subscribers/base.rb
+++ b/lib/lograge/log_subscribers/base.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require 'action_pack'
+require 'active_support'
 require 'active_support/core_ext/class/attribute'
 require 'active_support/log_subscriber'
 require 'request_store'

--- a/lib/lograge/ordered_options.rb
+++ b/lib/lograge/ordered_options.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support'
 require 'active_support/ordered_options'
 
 module Lograge

--- a/lib/lograge/rails_ext/rack/logger.rb
+++ b/lib/lograge/rails_ext/rack/logger.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support'
 require 'active_support/concern'
 require 'rails/rack/logger'
 

--- a/spec/log_subscribers/action_cable_spec.rb
+++ b/spec/log_subscribers/action_cable_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'lograge/log_subscribers/action_controller'
+require 'active_support'
 require 'active_support/notifications'
 require 'active_support/core_ext/string'
 require 'logger'

--- a/spec/log_subscribers/action_controller_spec.rb
+++ b/spec/log_subscribers/action_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'lograge/log_subscribers/action_controller'
+require 'active_support'
 require 'active_support/notifications'
 require 'active_support/core_ext/string'
 require 'logger'

--- a/spec/lograge_spec.rb
+++ b/spec/lograge_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support'
 require 'active_support/notifications'
 require 'active_support/core_ext/string'
 require 'active_support/deprecation'


### PR DESCRIPTION
This PR attempts to fix a thing seen in the test output here: https://github.com/roidrage/lograge/runs/4777416627?check_suite_focus=true

This has changed in later releases of ActiveSupport, see this Issue: https://github.com/rails/rails/issues/43851