### PR TITLE
build: Skip Rails edge (7.1.0.alpha) in JRuby in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         ruby:
           # MRI
           - head
-          - "3.1.0-preview1"
+          - "3.1.0"
           - "3.0"
           - "2.7"
 
@@ -29,7 +29,7 @@ jobs:
 
         gemfile:
           - Gemfile
-          - gemfiles/rails_edge.gemfile
+          - gemfiles/rails_edge.gemfile # 7.1.0.alpha
           - gemfiles/rails_6.0.gemfile
           - gemfiles/rails_5.2.gemfile
 
@@ -42,6 +42,13 @@ jobs:
             gemfile: gemfiles/rails_6.0.gemfile
           - ruby: "2.6"
             gemfile: gemfiles/rails_5.2.gemfile
+        exclude:
+          # NOTE(ivy): Rails 7 requires Ruby version >= 2.7
+          - ruby: jruby-9.3
+            gemfile: gemfiles/rails_edge.gemfile
+          - ruby: jruby-9.2
+            gemfile: gemfiles/rails_edge.gemfile
+
 
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}


### PR DESCRIPTION
This PR removes Rails 7-related gems from being run on JRuby (which does not implement Ruby 2.7).