### PR TITLE
Lograge setting path to an object for actioncable logs conflicts with http logs

### DIFF
--- a/lib/lograge/log_subscribers/action_cable.rb
+++ b/lib/lograge/log_subscribers/action_cable.rb
@@ -14,7 +14,7 @@ module Lograge
       def initial_data(payload)
         {
           method: {},
-          path: {},
+          path: "",
           format: {},
           params: payload[:data],
           controller: payload[:channel_class] || payload[:connection_class],


### PR DESCRIPTION
So my team notice that our log storage was blowing up with problems parsing our logs, turns out our action cable logs have a property called `path` that, while normally a string for http requests, is now an `{}`!

I don't know if this is the *right* change to make but I'd love to use it as a jumping off point to correct this issue.