### PR TITLE
Set TargetRubyVersion

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
     - Guardfile
     - vendor/**/*
   NewCops: enable
+  TargetRubyVersion: 2.5
 
 Layout/LineLength:
   Max: 120


### PR DESCRIPTION
Hi!
Set TargetRubyVersion because rubocop was failing on CI.