### PR TITLE
Remove dead code

### DIFF
--- a/lib/lograge/log_subscribers/action_controller.rb
+++ b/lib/lograge/log_subscribers/action_controller.rb
@@ -22,7 +22,7 @@ module Lograge
         {
           method: payload[:method],
           path: extract_path(payload),
-          format: extract_format(payload),
+          format: payload[:format],
           controller: payload[:controller],
           action: payload[:action]
         }
@@ -36,16 +36,6 @@ module Lograge
       def strip_query_string(path)
         index = path.index('?')
         index ? path[0, index] : path
-      end
-
-      if ::ActionPack::VERSION::MAJOR == 3 && ::ActionPack::VERSION::MINOR.zero?
-        def extract_format(payload)
-          payload[:formats].first
-        end
-      else
-        def extract_format(payload)
-          payload[:format]
-        end
       end
 
       def extract_runtimes(event, payload)


### PR DESCRIPTION
Rails 3 support was dropped in 2016 in commit 37922cd80bcdaaab0a2b67749cbbf9293c15b9d2