### PR TITLE
Call log_process_action to get the right status code (devise)

### DIFF
--- a/lib/lograge/log_subscribers/action_controller.rb
+++ b/lib/lograge/log_subscribers/action_controller.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
+require 'action_controller'
+
 module Lograge
   module LogSubscribers
     class ActionController < Base
       def process_action(event)
+        ::ActionController::Base.log_process_action(event.payload)
         process_main_event(event)
       end
 

--- a/spec/log_subscribers/action_controller_spec.rb
+++ b/spec/log_subscribers/action_controller_spec.rb
@@ -364,6 +364,15 @@ describe Lograge::LogSubscribers::ActionController do
     end
   end
 
+  context 'with a status code that is set in log_process_action (devise)' do
+    it 'returns the correct status code' do
+      allow(::ActionController::Base).to receive(:log_process_action) { |payload| payload[:status] = 401 }
+      event.payload[:status] = nil
+      subscriber.process_action(event)
+      expect(log_output.string).to match(/status=401 /)
+    end
+  end
+
   it "will fallback to ActiveSupport's logger if one isn't configured" do
     Lograge.formatter = Lograge::Formatters::KeyValue.new
     Lograge.logger = nil


### PR DESCRIPTION
This is a revival of #194 by @clupprich based on the latest master.

Devise did implement a fix (https://github.com/heartcombo/devise/pull/4375) for this, but which was quickly reverted (https://github.com/heartcombo/devise/pull/4804).

Locally with devise `4.8.1` and lograge `0.12.0` some of my logs are still populated with `status: 0`.
I've been able to reproduce this locally, and can confirm the issue is fixed with this change.