### PR TITLE
Remove extraneous `puts` from spec

### DIFF
--- a/spec/formatters/key_value_deep_spec.rb
+++ b/spec/formatters/key_value_deep_spec.rb
@@ -36,8 +36,7 @@ describe Lograge::Formatters::KeyValueDeep do
     expect(subject).to include('params_object_key_array_1=2')
   end
 
-  it 'return the correct serialization' do
-    puts subject
+  it 'returns the correct serialization' do
     expect(subject).to eq("custom=data status=200 method=GET path=/ \
 controller=welcome action=index params_object_key=value params_object_key_array_0=1 \
 params_object_key_array_1=2 params_object_key_array_2=3.40")


### PR DESCRIPTION
This was probably mistakenly forgotten in #282.
Also fixes a typo in the spec description.