### PR TITLE
Use a dedicated ActiveSupport::Deprecation

### DIFF
--- a/lib/lograge.rb
+++ b/lib/lograge.rb
@@ -216,13 +216,17 @@ module Lograge
 
     legacy_log_format = lograge_config.log_format
     warning = 'config.lograge.log_format is deprecated. Use config.lograge.formatter instead.'
-    ActiveSupport::Deprecation.warn(warning, caller)
+    deprecator.warn(warning, caller)
     legacy_log_format = :key_value if legacy_log_format == :lograge
     lograge_config.formatter = "Lograge::Formatters::#{legacy_log_format.to_s.classify}".constantize.new
   end
 
   def lograge_config
     application.config.lograge
+  end
+
+  def deprecator
+    @deprecator ||= ActiveSupport::Deprecation.new('1.0', 'Lograge')
   end
 
   if ::ActiveSupport::VERSION::MAJOR >= 8 ||

--- a/lib/lograge/railtie.rb
+++ b/lib/lograge/railtie.rb
@@ -9,6 +9,10 @@ module Lograge
     config.lograge = Lograge::OrderedOptions.new
     config.lograge.enabled = false
 
+    initializer :deprecator do |app|
+      app.deprecators[:lograge] = Lograge.deprecator if app.respond_to?(:deprecators)
+    end
+
     config.after_initialize do |app|
       Lograge.setup(app) if app.config.lograge.enabled
     end

--- a/spec/lograge_spec.rb
+++ b/spec/lograge_spec.rb
@@ -169,7 +169,7 @@ describe Lograge do
                 config.lograge.log_format = format
               end)
     end
-    before { ActiveSupport::Deprecation.silence { Lograge.setup(app_config) } }
+    before { Lograge.deprecator.silence { Lograge.setup(app_config) } }
     subject { Lograge.formatter }
 
     context ':cee' do


### PR DESCRIPTION
Rails 7.1 will deprecate using the singleton ActiveSupport::Deprecation instance (rails/rails#47354). This defines one for the gem and uses it.

It's also added to the application's set of deprecators, allowing it to be configured along all the other deprecators.