### PR TITLE
Fix broken CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           - jruby-9.2
 
           # TruffleRuby
-          - truffleruby-21.3
+          - truffleruby-23.0
 
         gemfile:
           - Gemfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
           # JRuby
           - jruby-9.3
-          - jruby-9.2
+          - jruby-9.4
 
           # TruffleRuby
           - truffleruby-23.0

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,6 @@ Style/BlockDelimiters:
 
 Style/Documentation:
   Enabled: false
+
+Gemspec/DevelopmentDependencies:
+  Enabled: false

--- a/lib/lograge.rb
+++ b/lib/lograge.rb
@@ -120,7 +120,7 @@ module Lograge
   def unsubscribe(component, subscriber)
     events = subscriber.public_methods(false).reject { |method| method.to_s == 'call' }
     events.each do |event|
-      ActiveSupport::Notifications.notifier.listeners_for("#{event}.#{component}").each do |listener|
+      Lograge.notification_listeners_for("#{event}.#{component}").each do |listener|
         ActiveSupport::Notifications.unsubscribe listener if listener.instance_variable_get('@delegate') == subscriber
       end
     end
@@ -223,6 +223,17 @@ module Lograge
 
   def lograge_config
     application.config.lograge
+  end
+
+  if ::ActiveSupport::VERSION::MAJOR >= 8 ||
+     (::ActiveSupport::VERSION::MAJOR >= 7 && ::ActiveSupport::VERSION::MINOR >= 1)
+    def notification_listeners_for(name)
+      ActiveSupport::Notifications.notifier.all_listeners_for(name)
+    end
+  else
+    def notification_listeners_for(name)
+      ActiveSupport::Notifications.notifier.listeners_for(name)
+    end
   end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/spec/lograge_spec.rb
+++ b/spec/lograge_spec.rb
@@ -5,6 +5,7 @@ require 'active_support/notifications'
 require 'active_support/core_ext/string'
 require 'active_support/deprecation'
 require 'active_support/log_subscriber'
+require 'action_controller'
 require 'action_controller/log_subscriber'
 require 'action_view/log_subscriber'
 

--- a/spec/lograge_spec.rb
+++ b/spec/lograge_spec.rb
@@ -117,6 +117,10 @@ describe Lograge do
         def current_user_id
           '24601'
         end
+
+        class << self
+          def logger; end
+        end
       end
     end
     let(:payload) { { timestamp: Date.parse('5-11-1955') } }

--- a/spec/lograge_spec.rb
+++ b/spec/lograge_spec.rb
@@ -20,7 +20,7 @@ describe Lograge do
       expect do
         Lograge.remove_existing_log_subscriptions
       end.to change {
-        ActiveSupport::Notifications.notifier.listeners_for('process_action.action_controller')
+        Lograge.notification_listeners_for('process_action.action_controller')
       }
     end
 
@@ -28,7 +28,7 @@ describe Lograge do
       expect do
         Lograge.remove_existing_log_subscriptions
       end.to change {
-        ActiveSupport::Notifications.notifier.listeners_for('render_template.action_view')
+        Lograge.notification_listeners_for('render_template.action_view')
       }
     end
 
@@ -36,7 +36,7 @@ describe Lograge do
       blk = -> {}
       ActiveSupport::Notifications.subscribe('process_action.action_controller', &blk)
       Lograge.remove_existing_log_subscriptions
-      listeners = ActiveSupport::Notifications.notifier.listeners_for('process_action.action_controller')
+      listeners = Lograge.notification_listeners_for('process_action.action_controller')
       expect(listeners.size).to eq(1)
     end
   end


### PR DESCRIPTION
This PR tries to fix the broken CI. 

First, disable `Gemspec/DependencyVersion` cop
    
Currently, CI is broken because of `Gemspec/DevelopmentDependencies` cop.
https://github.com/roidrage/lograge/actions/runs/5100966316/jobs/9169550600#step:4:36

Rubocop recommends to write development dependencies in Gemfile.
But this gem has multiple Gemfiles and it might be redundant. So I disable it to pass Rubocop.


Second,  bump `truffleruby` to the latest.
Because truffleruby-21.3 for Ubuntu 22.04 doesn't exist.
https://github.com/ruby/ruby-builder/releases/tag/toolcache

Third, support edge Rails. Since, https://github.com/rails/rails/pull/45796,
`ActiveSupport::Notifications.notifier.listeners_for` doesn't return all `listeners`.
Need to use `all_listeners_for` to get all `listeners`.

