### PR TITLE
Add halted_callback to the log output

### DIFF
--- a/lib/lograge/log_subscribers/base.rb
+++ b/lib/lograge/log_subscribers/base.rb
@@ -14,6 +14,10 @@ module Lograge
         Lograge.logger.presence || super
       end
 
+      def halted_callback(event)
+        RequestStore.store[:lograge_halted_callback] = event.payload[:filter]
+      end
+
       private
 
       def process_main_event(event)
@@ -33,6 +37,7 @@ module Lograge
         data.merge!(extract_runtimes(event, payload))
         data.merge!(extract_location)
         data.merge!(extract_unpermitted_params)
+        data.merge!(extract_halted_callback)
         data.merge!(custom_options(event))
       end
 
@@ -66,6 +71,14 @@ module Lograge
         else
           {}
         end
+      end
+
+      def extract_halted_callback
+        halted_callback = RequestStore.store[:lograge_halted_callback]
+        return {} unless halted_callback
+
+        RequestStore.store[:lograge_halted_callback] = nil
+        { halted_callback: halted_callback.to_s }
       end
 
       def custom_options(event)


### PR DESCRIPTION
> Sometimes when you do the final render or redirection, it can be halted by a controller callback. With the existing code, it can very hard to understand where it stopped.
> 
> With this commit, the intent is to provide the method name where it stops.

So I started from https://github.com/roidrage/lograge/pull/259 work and because it was not maintained anymore I moved the code the to base subscriber to have the halted callback.

Would that be the way to do it? Not sure but I try to keep @benoittgt code and integrate it in the codebase