### PR TITLE
Add formatter for the logstash-logger gem

### DIFF
--- a/lib/lograge/log_subscribers/action_controller.rb
+++ b/lib/lograge/log_subscribers/action_controller.rb
@@ -7,6 +7,10 @@ module Lograge
         process_main_event(event)
       end
 
+      def start_processing(event)
+        RequestStore.store[:lograge_event_payload] = event.payload.without(:headers, :params)
+      end
+
       def redirect_to(event)
         RequestStore.store[:lograge_location] = event.payload[:location]
       end

--- a/lib/lograge/log_subscribers/base.rb
+++ b/lib/lograge/log_subscribers/base.rb
@@ -69,6 +69,10 @@ module Lograge
       end
 
       def custom_options(event)
+        # TODO: unsure if MergedWithLogragePayload should care about the user's
+        # custom_options for now (if it did, it seems that it would only make sense
+        # to call custom_options twice, one for the process_action event as is, plus one for
+        # the newly listened to start_processing.)
         options = Lograge.custom_options(event) || {}
         options.merge event.payload[:custom_payload] || {}
       end

--- a/lib/lograge/logstash_logger_formatters/merged_with_lograge_payload.rb
+++ b/lib/lograge/logstash_logger_formatters/merged_with_lograge_payload.rb
@@ -1,0 +1,23 @@
+begin
+  require 'logstash-logger'
+  require 'logstash-event'
+rescue LoadError
+  puts 'You need to install the logstash-event and logstash-logger gems ' \
+    'to use Lograge::LogStashLoggerFormatters::MergedWithLogragePayload.'
+  raise
+end
+
+module Lograge
+  module LogStashLoggerFormatters
+    class MergedWithLogragePayload < LogStashLogger::Formatter::Base
+      private
+
+      def format_event(event)
+        lograge_event_payload = RequestStore.store[:lograge_event_payload] || {}
+        lograge_event_payload.merge!(RequestStore.store[:lograge_custom_payload] || {})
+        event.overwrite(event.fields.merge(lograge_event_payload))
+        "#{event.to_json}\n"
+      end
+    end
+  end
+end

--- a/spec/lograge_spec.rb
+++ b/spec/lograge_spec.rb
@@ -118,6 +118,10 @@ describe Lograge do
           '24601'
         end
 
+        def self.prepend_before_action(&block)
+          block.call(new)
+        end
+
         class << self
           def logger; end
         end


### PR DESCRIPTION
This is https://github.com/roidrage/lograge/pull/303 rebased against master.

Not that my feedback from https://github.com/roidrage/lograge/pull/303#issuecomment-1284884046 still applies - it's not an ideal implementation... but it works. It's been in production of a huge site for one year now.

For reference, `RequestStore.store[:lograge_event_payload]` is what this original PR adds to Lograge core, and then formatters or other custom loggers. Like my logger that is set as `Rails.logger` and therefore each non-Lograge line includes what Lograge logs for that request.


```
class Exceptions
  def self.to_s_truncated e, source
    unless e.is_a?(Exception)
      return '(not an exception)'
    end

    truncated_backtrace = []
    truncated_backtrace << "#{e.class.name}: #{e}"

    full_stack_size = e.backtrace.size
    truncated_backtrace += e.backtrace.first(5)
    if full_stack_size > 5
      truncated_backtrace << "(truncated; total frames: #{full_stack_size})"
    end

    truncated_backtrace.join("\n")
  end

  def self.to_s_one_line e, source
    unless e.is_a?(Exception)
      return '(not an exception)'
    end

    s = "#{e.class.name}: #{e}"

    if first_frame = e.backtrace.first
      s << " - #{first_frame}"
    end

    if source
      s << " via #{source}"
    end

    s
  end

  def self.to_lograge e, hash, event
    hash[:error] = Exceptions.to_s_one_line(e, 'lograge')
    hash[:appsignal] = "#{e.class.name} #{event.payload[:controller]}##{event.payload[:action]}"
  end

  class Logger < ::Logger
    %w(unknown fatal error warn info debug).each do |level|
      level_const = Logger.const_get level.upcase

      define_method level do |msg, controller = nil, &block|
        if msg.is_a? Exception
          msg = Exceptions.to_s_one_line(msg, 'logger')
        end

        if msg && controller
          event = RequestStore.store[:lograge_event_payload] || {}
          event.define_singleton_method :payload do
            event
          end

          if controller
            event.merge! Rails.configuration.lograge.custom_payload_method.call(controller)
            event.merge! Rails.configuration.lograge.custom_options.call(event, controller)
          end

          unless controller.is_a?(Rack::Attack::Request)
            event.merge! type: 'logger'
          end

          lograge_line = Rails.configuration.lograge.formatter.call(event)

          msg = "#{lograge_line} --- #{msg}"
        end

        add(level_const, msg, progname, &block)
      end
    end
  end
end
```