### PR TITLE
Display halted callbacks in log for Application Controller

### DIFF
--- a/lib/lograge/log_subscribers/action_controller.rb
+++ b/lib/lograge/log_subscribers/action_controller.rb
@@ -70,6 +70,14 @@ module Lograge
         RequestStore.store[:lograge_unpermitted_params] = nil
         { unpermitted_params: unpermitted_params }
       end
+
+      def extract_halted_callback
+        halted_callback = RequestStore.store[:lograge_halted_callback]
+        return {} unless halted_callback
+  
+        RequestStore.store[:lograge_halted_callback] = nil
+        { halted_callback: halted_callback }
+      end
     end
   end
 end

--- a/lib/lograge/log_subscribers/base.rb
+++ b/lib/lograge/log_subscribers/base.rb
@@ -33,11 +33,12 @@ module Lograge
         data.merge!(extract_runtimes(event, payload))
         data.merge!(extract_location)
         data.merge!(extract_unpermitted_params)
+        data.merge!(extract_halted_callback)
         data.merge!(custom_options(event))
       end
 
       %i[initial_data extract_status extract_runtimes
-         extract_location extract_unpermitted_params].each do |method_name|
+         extract_location extract_unpermitted_params extract_halted_callback].each do |method_name|
         define_method(method_name) { |*_arg| {} }
       end
 

--- a/spec/log_subscribers/action_controller_spec.rb
+++ b/spec/log_subscribers/action_controller_spec.rb
@@ -189,7 +189,28 @@ describe Lograge::LogSubscribers::ActionController do
       expect(log_output.string).to_not include('location=')
     end
 
-    context 'with unpermitted_parameters' do
+    context 'with halted_callback' do
+      before do
+        RequestStore.store[:lograge_halted_callback] = 'user_authenticated'
+      end
+
+      it 'adds the halted_callback to the log line' do
+        subscriber.process_action(event)
+        expect(log_output.string).to include('halted_callback=user_authenticated')
+      end
+
+      it 'removes the thread local variable' do
+        subscriber.process_action(event)
+        expect(RequestStore.store[:lograge_halted_callback]).to be_nil
+      end
+    end
+
+    it 'does not include halted_callback by default' do
+      subscriber.process_action(event)
+      expect(log_output.string).to_not include('halted_callback=')
+    end
+
+    context 'with unpermitted_params' do
       before do
         RequestStore.store[:lograge_unpermitted_params] = %w[florb blarf]
       end


### PR DESCRIPTION
Fix https://github.com/roidrage/lograge/issues/258

Sometimes when you do the final render or redirection, it can be halted by a controller callback. With the existing code, it can very hard to understand where it stopped.

With this commit, the intent is to provide the method name where it stops.

Close #259