### PR TITLE
Fix broken CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,11 @@ jobs:
             gemfile: gemfiles/rails_edge.gemfile
           - ruby: jruby-9.2
             gemfile: gemfiles/rails_7.0.gemfile
+          # NOTE: Rails edge requires Ruby version >= 3.1
+          - ruby: "2.7"
+            gemfile: gemfiles/rails_edge.gemfile
+          - ruby: "3.0"
+            gemfile: gemfiles/rails_edge.gemfile
 
 
     env:

--- a/lib/lograge/formatters/graylog2.rb
+++ b/lib/lograge/formatters/graylog2.rb
@@ -13,7 +13,7 @@ module Lograge
       end
 
       def underscore_prefix(key)
-        "_#{key}".to_sym
+        :"_#{key}"
       end
 
       def short_message(data)

--- a/lib/lograge/formatters/key_value_deep.rb
+++ b/lib/lograge/formatters/key_value_deep.rb
@@ -4,7 +4,7 @@ module Lograge
   module Formatters
     class KeyValueDeep < KeyValue
       def call(data)
-        super flatten_keys(data)
+        super(flatten_keys(data))
       end
 
       protected

--- a/lib/lograge/log_subscribers/base.rb
+++ b/lib/lograge/log_subscribers/base.rb
@@ -61,7 +61,7 @@ module Lograge
       end
 
       def extract_allocations(event)
-        if (allocations = (event.respond_to?(:allocations) && event.allocations))
+        if (allocations = event.respond_to?(:allocations) && event.allocations)
           { allocations: allocations }
         else
           {}


### PR DESCRIPTION
This PR fix to the following to fix the build 

* Don't ruby Rails edge test with old Rubies
  *  Ref: https://github.com/rails/rails/pull/50491
* Fix Rubocop offences 


CI against Ruby Edge is failing. This is because of the changing of standard libraries. Ref: https://github.com/roidrage/lograge/actions/runs/7498021609/job/20412500476?pr=384#step:4:8
