### PR TITLE
Fix broken C

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,11 @@ jobs:
             gemfile: gemfiles/rails_7.1.gemfile
           - ruby: jruby-9.2
             gemfile: gemfiles/rails_7.0.gemfile
+          # NOTE: Rails edge requires Ruby version >= 3.1
+          - ruby: "2.7"
+            gemfile: gemfiles/rails_edge.gemfile
+          - ruby: "3.0"
+            gemfile: gemfiles/rails_edge.gemfile
 
 
     env:

--- a/lib/lograge/formatters/graylog2.rb
+++ b/lib/lograge/formatters/graylog2.rb
@@ -13,7 +13,7 @@ module Lograge
       end
 
       def underscore_prefix(key)
-        "_#{key}".to_sym
+        :"_#{key}"
       end
 
       def short_message(data)

--- a/lib/lograge/formatters/key_value_deep.rb
+++ b/lib/lograge/formatters/key_value_deep.rb
@@ -4,7 +4,7 @@ module Lograge
   module Formatters
     class KeyValueDeep < KeyValue
       def call(data)
-        super flatten_keys(data)
+        super(flatten_keys(data))
       end
 
       protected

--- a/lib/lograge/formatters/l2met.rb
+++ b/lib/lograge/formatters/l2met.rb
@@ -40,7 +40,7 @@ module Lograge
       def format(key, value)
         key = "measure#page.#{key}" if value.is_a?(Float)
 
-        super(key, value)
+        super
       end
 
       def modify_payload(data)

--- a/lib/lograge/log_subscribers/base.rb
+++ b/lib/lograge/log_subscribers/base.rb
@@ -61,7 +61,7 @@ module Lograge
       end
 
       def extract_allocations(event)
-        if (allocations = (event.respond_to?(:allocations) && event.allocations))
+        if (allocations = event.respond_to?(:allocations) && event.allocations)
           { allocations: allocations }
         else
           {}

--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -22,12 +22,14 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files lib LICENSE.txt`.split("\n")
 
+  s.add_development_dependency 'base64'
+  s.add_development_dependency 'mutex_m'
   s.add_development_dependency 'rspec', '~> 3.1'
   s.add_development_dependency 'rubocop', '~> 1.23'
   s.add_development_dependency 'simplecov', '~> 0.21'
 
   s.add_runtime_dependency 'actionpack',    '>= 4'
   s.add_runtime_dependency 'activesupport', '>= 4'
-  s.add_runtime_dependency 'railties',      '>= 4'
+  s.add_runtime_dependency 'railties', '>= 4'
   s.add_runtime_dependency 'request_store', '~> 1.0'
 end


### PR DESCRIPTION
This PR fix to the following to fix the build.

* Don't ruby Rails edge test with old Rubies
  *  Ref: https://github.com/rails/rails/pull/50491
* Fix Rubocop offences 
* Add `mutex_m`a and `base64` to dev dependencies
  * `mutex_m` and `base64` are bundled gem since Ruby 3.4. Rails uses `mutex_m` and `base64` and newer versions add those as dependencies(https://github.com/rails/rails/pull/48907). But, old Rails aren't supported. So we need to add those gems to run CI.  