### PR TITLE
Use `ActiveSupport.on_load` to defer autoloaded Action Cable constants

### DIFF
--- a/lib/lograge/rails_ext/action_cable/channel/base.rb
+++ b/lib/lograge/rails_ext/action_cable/channel/base.rb
@@ -22,4 +22,7 @@ module Lograge
   end
 end
 
-ActionCable::Channel::Base.prepend(Lograge::ActionCable::ChannelInstrumentation)
+
+ActiveSupport.on_load(:action_cable_channel) do
+  ActionCable::Channel::Base.prepend(Lograge::ActionCable::ChannelInstrumentation)
+end

--- a/lib/lograge/rails_ext/action_cable/connection/base.rb
+++ b/lib/lograge/rails_ext/action_cable/connection/base.rb
@@ -18,4 +18,6 @@ module Lograge
   end
 end
 
-ActionCable::Connection::Base.prepend(Lograge::ActionCable::ConnectionInstrumentation)
+ActiveSupport.on_load(:action_cable_connection) do
+  ActionCable::Connection::Base.prepend(Lograge::ActionCable::ConnectionInstrumentation)
+end

--- a/lib/lograge/rails_ext/action_cable/server/base.rb
+++ b/lib/lograge/rails_ext/action_cable/server/base.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
-module ActionCable
-  module Server
-    class Base
-      mattr_accessor :logger
-      self.logger = Lograge::SilentLogger.new(config.logger)
+ActiveSupport.on_load(:action_cable) do
+  module ActionCable
+    module Server
+      class Base
+        mattr_accessor :logger
+        self.logger = Lograge::SilentLogger.new(config.logger)
+      end
     end
   end
 end


### PR DESCRIPTION
This wraps autoloaded Action Cable constants with on_load hooks to ensure they are deferred and speed up application boot:

- https://api.rubyonrails.org/classes/ActiveSupport/LazyLoadHooks.html
- https://island94.org/2024/07/on-the-importance-of-rails-code-reloading