### PR TITLE
Fix RuboCop offenses

### DIFF
--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop', '~> 1.23'
   s.add_development_dependency 'simplecov', '~> 0.21'
 
-  s.add_runtime_dependency 'actionpack',    '>= 4'
-  s.add_runtime_dependency 'activesupport', '>= 4'
-  s.add_runtime_dependency 'railties', '>= 4'
-  s.add_runtime_dependency 'request_store', '~> 1.0'
+  s.add_dependency 'actionpack',    '>= 4'
+  s.add_dependency 'activesupport', '>= 4'
+  s.add_dependency 'railties', '>= 4'
+  s.add_dependency 'request_store', '~> 1.0'
 end


### PR DESCRIPTION
This PR fixes following offenses.

```
Offenses:

lograge.gemspec:31:5: C: [Corrected] Gemspec/AddRuntimeDependency: Use add_dependency instead of add_runtime_dependency.
  s.add_runtime_dependency 'actionpack',    '>= 4'
    ^^^^^^^^^^^^^^^^^^^^^^
lograge.gemspec:32:5: C: [Corrected] Gemspec/AddRuntimeDependency: Use add_dependency instead of add_runtime_dependency.
  s.add_runtime_dependency 'activesupport', '>= 4'
    ^^^^^^^^^^^^^^^^^^^^^^
lograge.gemspec:33:5: C: [Corrected] Gemspec/AddRuntimeDependency: Use add_dependency instead of add_runtime_dependency.
  s.add_runtime_dependency 'railties', '>= 4'
    ^^^^^^^^^^^^^^^^^^^^^^
lograge.gemspec:34:5: C: [Corrected] Gemspec/AddRuntimeDependency: Use add_dependency instead of add_runtime_dependency.
  s.add_runtime_dependency 'request_store', '~> 1.0'
```