### PR TITLE
Run CI tests against Rails 7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
 
         gemfile:
           - Gemfile
-          - gemfiles/rails_edge.gemfile # 7.2.0.alpha
+          - gemfiles/rails_edge.gemfile # 8.0
+          - gemfiles/rails_7.2.gemfile
           - gemfiles/rails_7.1.gemfile
           - gemfiles/rails_7.0.gemfile
           - gemfiles/rails_6.1.gemfile
@@ -51,15 +52,24 @@ jobs:
           - ruby: jruby-9.3
             gemfile: gemfiles/rails_edge.gemfile
           - ruby: jruby-9.3
+            gemfile: gemfiles/rails_7.2.gemfile
+          - ruby: jruby-9.3
             gemfile: gemfiles/rails_7.1.gemfile
           - ruby: jruby-9.3
             gemfile: gemfiles/rails_7.0.gemfile
           - ruby: jruby-9.2
             gemfile: gemfiles/rails_edge.gemfile
           - ruby: jruby-9.2
+            gemfile: gemfiles/rails_7.2.gemfile
+          - ruby: jruby-9.2
             gemfile: gemfiles/rails_7.1.gemfile
           - ruby: jruby-9.2
             gemfile: gemfiles/rails_7.0.gemfile
+          # NOTE: Rails 7.2 requires Ruby version >= 3.1
+          - ruby: "2.7"
+            gemfile: gemfiles/rails_7.2.gemfile
+          - ruby: "3.0"
+            gemfile: gemfiles/rails_7.2.gemfile
           # NOTE: Rails edge requires Ruby version >= 3.1
           - ruby: "2.7"
             gemfile: gemfiles/rails_edge.gemfile

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 Gemfile.lock
 coverage
 gemfiles/*.lock
+gemfiles/vendor
 pkg/*
 vendor/bundle

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ default, instead it assumes you use a proper log formatter instead.
 Lograge is actively tested against current and officially supported Ruby and
 Rails releases. That said, Lograge _should_ work with older releases.
 
-- [Rails](https://endoflife.date/rails): Edge, 6.1, 6.0, 5.2
+- [Rails](https://endoflife.date/rails): Edge, 7.2, 7.1, 7.0, 6.1, 6.0, 5.2
 - Rubies:
-  - [MRI](https://endoflife.date/ruby): HEAD, 3.1.0-preview1, 3.0, 2.7, 2.6
+  - [MRI](https://endoflife.date/ruby): HEAD, 3.2, 3.1, 3.0, 2.7, 2.6
   - JRuby: HEAD, 9.2, 9.1
   - TruffleRuby: HEAD, 21.3
 

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in lograge.gemspec
+gemspec path: '..'
+
+group :test do
+  gem 'actionpack', '~> 7.2.0'
+  gem 'activerecord', '~> 7.2.0'
+  # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
+  # Using the tag is an attempt of having a stable version to test against where we can ensure that
+  # we test against the correct code.
+  gem 'logstash-event', git: 'https://github.com/elastic/logstash', tag: 'v1.5.4'
+  # logstash 1.5.4 is only supported with jrjackson up to  0.2.9
+  gem 'jrjackson', '~> 0.2.9', platforms: :jruby
+  gem 'lines'
+  gem 'thread_safe'
+end


### PR DESCRIPTION
Hi, based on [Rails 7.2 release](https://rubyonrails.org/2024/8/10/Rails-7-2-0-has-been-released), this pull request makes CI run tests against Rails 7.2.

I thought I should add Ruby 3.3 to the matrix as well, but I found https://github.com/roidrage/lograge/pull/383 so this pull request just add Rails 7.2.