### PR TITLE
ci: refresh matrix for 2026 Ruby/Rails, fix TruffleRuby build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.gemfile == 'gemfiles/rails_edge.gemfile' }}
 
     strategy:
+      # Don't let one leg's failure cancel the rest of the matrix.
+      fail-fast: false
       matrix:
         ruby:
           # MRI
@@ -24,15 +26,16 @@ jobs:
           - "3.4"
 
           # JRuby
-          - jruby-9.3
           - jruby-9.4
+          - jruby-10.0
 
           # TruffleRuby
-          - truffleruby-23.0
+          - truffleruby-34.0.1
 
         gemfile:
           - Gemfile
-          - gemfiles/rails_edge.gemfile # 8.1
+          - gemfiles/rails_edge.gemfile # 8.2
+          - gemfiles/rails_8.1.gemfile
           - gemfiles/rails_8.0.gemfile
           - gemfiles/rails_7.2.gemfile
           - gemfiles/rails_7.1.gemfile
@@ -43,61 +46,52 @@ jobs:
 
         # Include additional ruby/gemfile combinations:
         include:
-          # NOTE(ivy): Rails 7 requires Ruby version >= 2.7
+          # Older Rubies paired with the oldest supported Rails.
           - ruby: "2.6"
             gemfile: Gemfile
           - ruby: "2.6"
             gemfile: gemfiles/rails_6.0.gemfile
           - ruby: "2.6"
             gemfile: gemfiles/rails_5.2.gemfile
+          # Ruby 4.0 is only exercised against currently-supported Rails.
+          - ruby: "4.0"
+            gemfile: gemfiles/rails_8.1.gemfile
+          - ruby: "4.0"
+            gemfile: gemfiles/rails_8.0.gemfile
+          - ruby: "4.0"
+            gemfile: gemfiles/rails_edge.gemfile
         exclude:
-          # NOTE(ivy): Rails 7 requires Ruby version >= 2.7
-          - ruby: jruby-9.3
+          # JRuby 9.4 targets Ruby 3.1 — too old for Rails 8.0+ (needs >= 3.2).
+          - ruby: jruby-9.4
             gemfile: gemfiles/rails_edge.gemfile
-          - ruby: jruby-9.3
-            gemfile: gemfiles/rails_7.2.gemfile
-          - ruby: jruby-9.3
-            gemfile: gemfiles/rails_7.1.gemfile
-          - ruby: jruby-9.3
-            gemfile: gemfiles/rails_7.0.gemfile
-          - ruby: jruby-9.2
-            gemfile: gemfiles/rails_edge.gemfile
-          - ruby: jruby-9.2
-            gemfile: gemfiles/rails_7.2.gemfile
-          - ruby: jruby-9.2
-            gemfile: gemfiles/rails_7.1.gemfile
-          - ruby: jruby-9.2
-            gemfile: gemfiles/rails_7.0.gemfile
+          - ruby: jruby-9.4
+            gemfile: gemfiles/rails_8.1.gemfile
+          - ruby: jruby-9.4
+            gemfile: gemfiles/rails_8.0.gemfile
           # NOTE: Rails 7.2 requires Ruby version >= 3.1
           - ruby: "2.7"
             gemfile: gemfiles/rails_7.2.gemfile
           - ruby: "3.0"
             gemfile: gemfiles/rails_7.2.gemfile
-          # NOTE: Rails 8.0 edge requires Ruby version >= 3.2
+          # NOTE: Rails 8.0/8.1 require Ruby version >= 3.2
           - ruby: "2.7"
             gemfile: gemfiles/rails_8.0.gemfile
           - ruby: "3.0"
             gemfile: gemfiles/rails_8.0.gemfile
           - ruby: "3.1"
             gemfile: gemfiles/rails_8.0.gemfile
-          - ruby: jruby-9.3
-            gemfile: gemfiles/rails_8.0.gemfile
-          - ruby: jruby-9.4
-            gemfile: gemfiles/rails_8.0.gemfile
-          - ruby: truffleruby-23.0
-            gemfile: gemfiles/rails_8.0.gemfile
+          - ruby: "2.7"
+            gemfile: gemfiles/rails_8.1.gemfile
+          - ruby: "3.0"
+            gemfile: gemfiles/rails_8.1.gemfile
+          - ruby: "3.1"
+            gemfile: gemfiles/rails_8.1.gemfile
           # NOTE: Rails edge requires Ruby version >= 3.2
           - ruby: "2.7"
             gemfile: gemfiles/rails_edge.gemfile
           - ruby: "3.0"
             gemfile: gemfiles/rails_edge.gemfile
           - ruby: "3.1"
-            gemfile: gemfiles/rails_edge.gemfile
-          - ruby: jruby-9.3
-            gemfile: gemfiles/rails_edge.gemfile
-          - ruby: jruby-9.4
-            gemfile: gemfiles/rails_edge.gemfile
-          - ruby: truffleruby-23.0
             gemfile: gemfiles/rails_edge.gemfile
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### Unreleased
 
+### 0.15.0
+
+* Test and support Rails 7.2, 8.0, and 8.1 [#399](https://github.com/roidrage/lograge/pull/399), [#400](https://github.com/roidrage/lograge/pull/400)
+* Test and support Ruby 3.4 and 4.0, JRuby 10.0, and TruffleRuby 34 [#399](https://github.com/roidrage/lograge/pull/399), [#400](https://github.com/roidrage/lograge/pull/400)
+* Explicitly `require 'logger'` to fix loading on Ruby 3.4+ where it is no longer autoloaded [#399](https://github.com/roidrage/lograge/pull/399)
+* Replace deprecated `add_runtime_dependency` with `add_dependency` in the gemspec [#399](https://github.com/roidrage/lograge/pull/399)
+
 ### 0.14.0
 
 * Add Rails 7.1 dedicated `ActiveSupport::Deprecation` [#365](https://github.com/roidrage/lograge/pull/365)

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ default, instead it assumes you use a proper log formatter instead.
 Lograge is actively tested against current and officially supported Ruby and
 Rails releases. That said, Lograge _should_ work with older releases.
 
-- [Rails](https://endoflife.date/rails): Edge, 8.0, 7.2, 7.1, 7.0, 6.1, 6.0, 5.2
+- [Rails](https://endoflife.date/rails): Edge, 8.1, 8.0, 7.2, 7.1, 7.0, 6.1, 6.0, 5.2
 - Rubies:
-  - [MRI](https://endoflife.date/ruby): HEAD, 3.4, 3.3, 3.2, 3.1, 3.0, 2.7, 2.6
-  - JRuby: 9.4, 9.3
-  - TruffleRuby: 23.0
+  - [MRI](https://endoflife.date/ruby): HEAD, 4.0, 3.4, 3.3, 3.2, 3.1, 3.0, 2.7, 2.6
+  - JRuby: 10.0, 9.4
+  - TruffleRuby: 34.0
 
 ## Installation ##
 

--- a/README.md
+++ b/README.md
@@ -46,14 +46,19 @@ default, instead it assumes you use a proper log formatter instead.
 
 ## Supported Ruby and Rails Releases ##
 
-Lograge is actively tested against current and officially supported Ruby and
-Rails releases. That said, Lograge _should_ work with older releases.
+The versions below are verified green in CI and are officially supported by
+this release. Lograge _should_ also work with older releases, though they are
+not actively tested.
 
-- [Rails](https://endoflife.date/rails): Edge, 8.1, 8.0, 7.2, 7.1, 7.0, 6.1, 6.0, 5.2
+- [Rails](https://endoflife.date/rails): 8.1, 8.0, 7.2, 7.1, 7.0, 6.1, 6.0, 5.2
 - Rubies:
-  - [MRI](https://endoflife.date/ruby): HEAD, 4.0, 3.4, 3.3, 3.2, 3.1, 3.0, 2.7, 2.6
+  - [MRI](https://endoflife.date/ruby): 4.0, 3.4, 3.3, 3.2, 3.1, 3.0, 2.7, 2.6
   - JRuby: 10.0, 9.4
   - TruffleRuby: 34.0
+
+Rails `main` (edge) and Ruby `head` are also exercised in CI on a best-effort
+basis to catch upcoming incompatibilities early. They are allowed to fail and
+are **not** yet officially supported.
 
 ## Installation ##
 

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in lograge.gemspec
+gemspec path: '..'
+
+group :test do
+  gem 'actionpack', '~> 8.1.0'
+  gem 'activerecord', '~> 8.1.0'
+  # logstash does not release any gems on rubygems, but they have two gemspecs within their repo.
+  # Using the tag is an attempt of having a stable version to test against where we can ensure that
+  # we test against the correct code.
+  gem 'logstash-event', git: 'https://github.com/elastic/logstash', tag: 'v1.5.4'
+  # logstash 1.5.4 is only supported with jrjackson up to  0.2.9
+  gem 'jrjackson', '~> 0.2.9', platforms: :jruby
+  gem 'lines'
+  gem 'thread_safe'
+end

--- a/lib/lograge/version.rb
+++ b/lib/lograge/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Lograge
-  VERSION = '0.14.0'
+  VERSION = '0.15.0'
 end

--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -22,8 +22,15 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files lib LICENSE.txt`.split("\n")
 
+  # base64, bigdecimal and mutex_m were extracted from the default gems in
+  # Ruby 3.4; older Rails releases still `require` them, and JRuby (which
+  # targets Ruby 3.4) does not bundle them, so declare them explicitly.
   s.add_development_dependency 'base64'
+  s.add_development_dependency 'bigdecimal'
   s.add_development_dependency 'mutex_m'
+  # rdoc 8 depends on rbs, whose C extension cannot be built on JRuby. Keep
+  # rdoc on the pre-rbs line so the JRuby test matrix can bundle.
+  s.add_development_dependency 'rdoc', '< 8'
   s.add_development_dependency 'rspec', '~> 3.1'
   s.add_development_dependency 'rubocop', '~> 1.23'
   s.add_development_dependency 'simplecov', '~> 0.21'


### PR DESCRIPTION
The pinned truffleruby-23.0 could no longer build modern native gems (json 2.20.0, pulled in transitively via rubocop), which hard-failed and, without fail-fast: false, cancelled the rest of the matrix. This refreshes the toolchain and expands coverage to the current ecosystem.

* Bump TruffleRuby 23.0 -> 34.0.1 (Ruby 3.4 compat) to fix the native build
* Add fail-fast: false so one leg's failure can't cancel healthy jobs
* Add Rails 8.1 (gemfiles/rails_8.1.gemfile) to the matrix
* Add Ruby 4.0, scoped to currently-supported Rails (8.1, 8.0, edge)
* Add JRuby 10.0 (LTS); drop EOL JRuby 9.3
* Bump edge marker to Rails 8.2; prune dead jruby-9.2/truffleruby excludes
* Update README supported-version list

Verified locally: Rails 8.1 on Ruby 3.4 passes (133 examples, 0 failures), RuboCop clean. Ruby 4.0 combos still need real-CI confirmation. The remaining allowed failures are Ruby head and rails_edge (8.2 removed ActionController::LogSubscriber#attach_to), both continue-on-error.