### PR TITLE
Drop Ruby 3.2 from Rails edge test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,12 +86,14 @@ jobs:
             gemfile: gemfiles/rails_8.1.gemfile
           - ruby: "3.1"
             gemfile: gemfiles/rails_8.1.gemfile
-          # NOTE: Rails edge requires Ruby version >= 3.2
+          # NOTE: Rails edge requires Ruby version >= 3.3
           - ruby: "2.7"
             gemfile: gemfiles/rails_edge.gemfile
           - ruby: "3.0"
             gemfile: gemfiles/rails_edge.gemfile
           - ruby: "3.1"
+            gemfile: gemfiles/rails_edge.gemfile
+          - ruby: "3.2"
             gemfile: gemfiles/rails_edge.gemfile
 
 


### PR DESCRIPTION
Rails edge currently requires Ruby >= 3.3(.1), so testing against Ruby 3.2 no longer reflects a supported combination.

---

Ref:
- https://github.com/rails/rails/blob/4aafd831a6e4c2979e43a4069f1415860d6ffc1e/rails.gemspec#L12
- https://github.com/roidrage/lograge/actions/runs/28880833217/job/85668282950
    ```
    Because every version of activerecord depends on Ruby >= 3.3.1
      and rails_edge.gemfile depends on activerecord >= 0,
      Ruby >= 3.3.1 is required.
    So, because current Ruby version is = 3.2.11,
      version solving has failed.
    ```