### PR TITLE
Remove misleading RuboCop comment in gemspec

### DIFF
--- a/lograge.gemspec
+++ b/lograge.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
     'changelog_uri' => 'https://github.com/roidrage/lograge/blob/master/CHANGELOG.md'
   }
 
-  # NOTE(ivy): Ruby version 2.5 is the oldest syntax supported by Rubocop.
   s.required_ruby_version = '>= 2.5'
 
   s.files = `git ls-files lib LICENSE.txt`.split("\n")


### PR DESCRIPTION
The comment claimed Ruby 2.5 was the oldest syntax supported by RuboCop, but this was only true briefly in RuboCop 1.28 (Apr 2022) when runtime and code analysis support were accidentally dropped together.

RuboCop quickly restored code analysis support:
- PR rubocop/rubocop#10626 (May 12 2022 v1.29.1) restored TargetRubyVersion 2.5
- PR rubocop/rubocop#10668 (May 25 2022) restored TargetRubyVersion 2.0

RuboCop now supports analyzing Ruby 2.0+ code, so the comment is misleading and should be removed.

The gem's minimum Ruby version is a project-level decision best guided by its own compatibility goals rather than by the support matrix of any single development tool. With Ruby 3.2 being the current minimum non-EOL release, >= 2.5 already offers generous backward compatibility.